### PR TITLE
(WIP) Setup Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+environment:
+  RUST_BACKTRACE: 1
+  RUST_CHANNEL: "%Configuration%"
+  matrix:
+  - TARGET: gnu
+    LLVM_VERSION: 3.9.0-2
+    BINDGEN_FEATURES: testing_only_libclang_3_9
+  - TARGET: gnu
+    LLVM_VERSION: 4.0.0-1
+    BINDGEN_FEATURES: testing_only_libclang_4
+  - TARGET: msvc
+    LLVM_VERSION: 3.9.0
+    BINDGEN_FEATURES: testing_only_libclang_3_9
+  - TARGET: msvc
+    LLVM_VERSION: 4.0.0
+    BINDGEN_FEATURES: testing_only_libclang_4
+
+configuration:
+- stable
+- nightly
+
+platform:
+  - x64
+  - x86
+
+branches:
+  only:
+    - master
+
+install:
+  - if %PLATFORM% == x86 (set RUST_PLATFORM=i686&set MINGW_BITS=32) else (set RUST_PLATFORM=x86_64&set MINGW_BITS=64)
+  - echo %RUST_CHANNEL%
+  - echo %RUST_PLATFORM%
+  - echo %MINGW_BITS%
+  - echo %RUST_PLATFORM%-pc-windows-%TARGET%
+  # install Rust
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-host %RUST_PLATFORM%-pc-windows-%TARGET% --default-toolchain %RUST_CHANNEL%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  # install LLVM for GNU
+  - if %TARGET%==gnu set PATH=C:\msys64\mingw%MINGW_BITS%\bin;C:\msys64\usr\bin\;%PATH%
+  - if %TARGET%==gnu set "MINGW_URL=http://repo.msys2.org/mingw/%RUST_PLATFORM%/mingw-w64-%RUST_PLATFORM%"
+  - if %TARGET%==gnu set "URL_VER=%LLVM_VERSION%-any.pkg.tar.xz"
+  - if %TARGET%==gnu bash -lc "pacman -U --noconfirm $MINGW_URL-clang-$URL_VER $MINGW_URL-llvm-$URL_VER"
+  - if %TARGET%==gnu bash -lc "clang --version"
+  # install LLVM for MSVC
+  - if %TARGET%==msvc appveyor-retry appveyor DownloadFile http://releases.llvm.org/%LLVM_VERSION%/LLVM-%LLVM_VERSION%-win64.exe -FileName llvm-installer.exe
+  - if %TARGET%==msvc 7z x llvm-installer.exe -oc:\llvm-binary
+  - if %TARGET%==msvc set PATH=C:\llvm-binary\bin;%PATH%
+  - if %TARGET%==msvc where clang
+  - if %TARGET%==msvc clang --version
+
+build_script:
+  - if %TARGET%==msvc .\ci\test.bat
+  - if %TARGET%==gnu bash -lc "export BINDGEN_FEATURES=$BINDGEN_FEATURES; cd $APPVEYOR_BUILD_FOLDER; ./ci/test.sh"
+
+test: off

--- a/ci/assert-no-diff.bat
+++ b/ci/assert-no-diff.bat
@@ -1,0 +1,7 @@
+@echo off
+
+cd "%~dp0.."
+
+git add -u
+git diff @
+git diff-index --quiet HEAD

--- a/ci/test.bat
+++ b/ci/test.bat
@@ -1,0 +1,49 @@
+@echo off
+
+cd "%~dp0.."
+
+set RUST_BACKTRACE=1
+
+if not defined BINDGEN_FEATURES (
+  echo Environment variable BINDGEN_FEATURES must be defined.
+  exit /B 1
+)
+
+findstr /r /c:"#include *<.*>" tests\headers\* >nul 2>&1 && (
+  echo Found a test with an #include directive of a system header file!
+  echo.
+  echo There is no guarantee that the system running the tests has the header
+  echo file, let alone the same version of it that you have. Any test with such an
+  echo include directive won't reliably produce the consistent bindings across systems.
+  exit /B 1
+) || (
+  echo Found none. OK!
+  set ERRORLEVEL=0
+)
+
+@echo on
+
+::Regenerate the test headers' bindings in debug and release modes, and assert
+::that we always get the expected generated bindings.
+
+cargo test --features "%BINDGEN_FEATURES%" || exit /b 1
+call .\ci\assert-no-diff.bat
+
+cargo test --features "%BINDGEN_FEATURES% testing_only_extra_assertions" || exit /b 1
+call .\ci\assert-no-diff.bat
+
+cargo test --release --features "%BINDGEN_FEATURES% testing_only_extra_assertions" || exit /b 1
+call .\ci\assert-no-diff.bat
+
+::Now test the expectations' size and alignment tests.
+
+pushd tests\expectations
+cargo test || exit /b 1
+cargo test --release || exit /b 1
+popd
+
+::And finally, test our example bindgen + build.rs integration template project.
+
+cd bindgen-integration
+cargo test --features "%BINDGEN_FEATURES%" || exit /b 1
+cargo test --release --features "%BINDGEN_FEATURES%" || exit /b 1

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -20,15 +20,19 @@ cargo test --features "$BINDGEN_FEATURES testing_only_extra_assertions"
 cargo test --release --features "$BINDGEN_FEATURES testing_only_extra_assertions"
 ./ci/assert-no-diff.sh
 
-# Now test the expectations' size and alignment tests.
+if [ -v "${TRAVIS_OS_NAME}" ]; then
 
-pushd tests/expectations
-cargo test
-cargo test --release
-popd
+    # Now test the expectations' size and alignment tests.
 
-# And finally, test our example bindgen + build.rs integration template project.
+    pushd tests/expectations
+    cargo test
+    cargo test --release
+    popd
 
-cd bindgen-integration
-cargo test --features "$BINDGEN_FEATURES"
-cargo test --release --features "$BINDGEN_FEATURES"
+    # And finally, test our example bindgen + build.rs integration template project.
+
+    cd bindgen-integration
+    cargo test --features "$BINDGEN_FEATURES"
+    cargo test --release --features "$BINDGEN_FEATURES"
+
+fi


### PR DESCRIPTION
CC @upsuper @emilio 

Issues:
- `test/expectations` fails at:
```
error[E0512]: transmute called with differently sized types: u64 (64 bits) to i32 (32 bits)
  --> tests\bitfield_align_2.rs:78:18
   |
78 |         unsafe { ::std::mem::transmute(val as u64) }
   |                  ^^^^^^^^^^^^^^^^^^^^^ transmuting between 64 bits and 32 bits
```
- MSVC with LLVM 3.9: many tests fails
- 32-bit builds: many tests fails

Appveyor build: https://ci.appveyor.com/project/UK992/rust-bindgen/build/1.0.62
