### PR TITLE
Fix recursive whitelisting and handling of opaque for derive default

### DIFF
--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -9,7 +9,7 @@
 /// and replacement for another type that doesn't implement it would prevent it
 /// from building if --no-derive-debug didn't work.
 #[repr(C)]
-#[derive(Default, Copy)]
+#[derive(Copy)]
 pub struct bar {
     pub foo: foo,
     pub baz: ::std::os::raw::c_int,
@@ -33,4 +33,7 @@ fn bindgen_test_layout_bar() {
 }
 impl Clone for bar {
     fn clone(&self) -> Self { *self }
+}
+impl Default for bar {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }

--- a/tests/expectations/tests/no-recursive-whitelisting.rs
+++ b/tests/expectations/tests/no-recursive-whitelisting.rs
@@ -6,7 +6,7 @@
 pub enum Bar {}
 
 #[repr(C)]
-#[derive(Debug, Default, Copy)]
+#[derive(Debug, Copy)]
 pub struct Foo {
     pub baz: *mut Bar,
 }
@@ -24,4 +24,7 @@ fn bindgen_test_layout_Foo() {
 }
 impl Clone for Foo {
     fn clone(&self) -> Self { *self }
+}
+impl Default for Foo {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -5,11 +5,8 @@
 
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct OpaqueTemplate {
-}
-impl Default for OpaqueTemplate {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy)]

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -5,11 +5,8 @@
 
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct OpaqueTemplate {
-}
-impl Default for OpaqueTemplate {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
 pub struct ContainsOpaqueTemplate {

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -22,11 +22,8 @@ impl Clone for OtherOpaque {
 }
 /// <div rustbindgen opaque></div>
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Opaque {
-}
-impl Default for Opaque {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -171,11 +171,8 @@ impl Default for PODButContainsDtor {
 }
 /// <div rustbindgen opaque>
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Opaque {
-}
-impl Default for Opaque {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy)]


### PR DESCRIPTION
Fix regression of derive default analysis.   
Also fix opaque handing exposed by the above fix. r? @fitzgen 

