### PR TITLE
Adds support for running rustfmt on generated bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -340,6 +341,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "which"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,5 +402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum which 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d238435618c0f298d2d75596c2d4fa7d4ea469c0c1c3ff824737ed50ad5ab61c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ syntex_syntax = "0.58"
 regex = "0.2"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = "2"
+which = "1.0.2"
 
 [dependencies.aster]
 features = ["with-syntex"]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -175,7 +175,7 @@ impl<'a> CodegenResult<'a> {
     /// counter internally so the next time we ask for the overload for this
     /// name, we get the incremented value, and so on.
     fn overload_number(&mut self, name: &str) -> u32 {
-        let mut counter =
+        let counter =
             self.overload_counters.entry(name.into()).or_insert(0);
         let number = *counter;
         *counter += 1;
@@ -2030,7 +2030,7 @@ impl MethodCodegen for Method {
         }
 
         let count = {
-            let mut count = method_names.entry(name.clone()).or_insert(0);
+            let count = method_names.entry(name.clone()).or_insert(0);
             *count += 1;
             *count - 1
         };

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -460,7 +460,7 @@ fn raw_fields_to_fields_and_bitfield_units<I>(ctx: &BindgenContext,
 /// (potentially multiple) bitfield units.
 fn bitfields_to_allocation_units<E, I>(ctx: &BindgenContext,
                                        bitfield_unit_count: &mut usize,
-                                       mut fields: &mut E,
+                                       fields: &mut E,
                                        raw_bitfields: I)
     where E: Extend<Field>,
           I: IntoIterator<Item=RawField>
@@ -478,7 +478,7 @@ fn bitfields_to_allocation_units<E, I>(ctx: &BindgenContext,
     // TODO(emilio): Take into account C++'s wide bitfields, and
     // packing, sigh.
 
-    fn flush_allocation_unit<E>(mut fields: &mut E,
+    fn flush_allocation_unit<E>(fields: &mut E,
                                 bitfield_unit_count: &mut usize,
                                 unit_size_in_bits: usize,
                                 unit_align_in_bits: usize,

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -466,8 +466,8 @@ impl<'ctx> BindgenContext<'ctx> {
         assert!(item.id() != self.root_module);
         assert!(!self.items.contains_key(&item.id()));
 
-        if let Some(mut parent) = self.items.get_mut(&item.parent_id()) {
-            if let Some(mut module) = parent.as_module_mut() {
+        if let Some(parent) = self.items.get_mut(&item.parent_id()) {
+            if let Some(module) = parent.as_module_mut() {
                 debug!("add_item_to_module: adding {:?} as child of parent module {:?}",
                        item.id(),
                        item.parent_id());
@@ -607,7 +607,7 @@ impl<'ctx> BindgenContext<'ctx> {
                                to opaque blob");
                         Item::new_opaque_type(self.next_item_id(), &ty, self)
                     });
-                let mut item = self.items.get_mut(&id).unwrap();
+                let item = self.items.get_mut(&id).unwrap();
 
                 *item.kind_mut().as_type_mut().unwrap().kind_mut() =
                     TypeKind::ResolvedTypeRef(resolved);
@@ -699,7 +699,7 @@ impl<'ctx> BindgenContext<'ctx> {
             debug!("Replacing {:?} with {:?}", id, replacement);
 
             let new_parent = {
-                let mut item = self.items.get_mut(&id).unwrap();
+                let item = self.items.get_mut(&id).unwrap();
                 *item.kind_mut().as_type_mut().unwrap().kind_mut() =
                     TypeKind::ResolvedTypeRef(replacement);
                 item.parent_id()

--- a/src/ir/template.rs
+++ b/src/ir/template.rs
@@ -322,7 +322,7 @@ impl IsOpaque for TemplateInstantiation {
                 arg_path[1..].join("::")
             }).collect();
         {
-            let mut last = path.last_mut().unwrap();
+            let last = path.last_mut().unwrap();
             last.push('<');
             last.push_str(&args.join(", "));
             last.push('>');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1218,7 +1218,7 @@ impl Default for BindgenOptions {
             objc_extern_crate: false,
             enable_mangling: true,
             prepend_enum_name: true,
-            rustfmt_bindings: true,
+            rustfmt_bindings: false,
             rustfmt_configuration_file: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,13 +456,16 @@ impl Builder {
             );
         }
 
-        if !self.options.format_bindings {
-            output_vector.push("--format-bindings".into());
+        if !self.options.rustfmt_bindings {
+            output_vector.push("--rustfmt-bindings".into());
         }
 
-        if let Some(path) = self.options.format_configuration_file.as_ref().and_then(
-            |f| f.to_str()) {
-            output_vector.push("--format-configuration-file".into());
+        if let Some(path) = self.options
+            .rustfmt_configuration_file
+            .as_ref()
+            .and_then(|f| f.to_str())
+        {
+            output_vector.push("--rustfmt-configuration-file".into());
             output_vector.push(path.into());
         }
 
@@ -852,15 +855,16 @@ impl Builder {
     }
 
     /// Set whether rustfmt should format the generated bindings.
-    pub fn format_bindings(mut self, doit: bool) -> Self {
-        self.options.format_bindings = doit;
+    pub fn rustfmt_bindings(mut self, doit: bool) -> Self {
+        self.options.rustfmt_bindings = doit;
         self
     }
 
     /// Set the absolute path to the rustfmt configuration file, if None, the standard rustfmt
     /// options are used.
-    pub fn format_configuration_file(mut self, path: Option<PathBuf>) -> Self {
-        self.options.format_configuration_file = path;
+    pub fn rustfmt_configuration_file(mut self, path: Option<PathBuf>) -> Self {
+        self = self.rustfmt_bindings(true);
+        self.options.rustfmt_configuration_file = path;
         self
     }
 
@@ -1125,11 +1129,11 @@ pub struct BindgenOptions {
     rust_features: RustFeatures,
 
     /// Whether rustfmt should format the generated bindings.
-    pub format_bindings: bool,
+    pub rustfmt_bindings: bool,
 
     /// The absolute path to the rustfmt configuration file, if None, the standard rustfmt
     /// options are used.
-    pub format_configuration_file: Option<PathBuf>,
+    pub rustfmt_configuration_file: Option<PathBuf>,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -1214,8 +1218,8 @@ impl Default for BindgenOptions {
             objc_extern_crate: false,
             enable_mangling: true,
             prepend_enum_name: true,
-            format_bindings: true,
-            format_configuration_file: None,
+            rustfmt_bindings: true,
+            rustfmt_configuration_file: None,
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -233,15 +233,15 @@ where
                        Useful when debugging bindgen, using C-Reduce, or when \
                        filing issues. The resulting file will be named \
                        something like `__bindgen.i` or `__bindgen.ii`."),
-            Arg::with_name("format-bindings")
-                .long("format-bindings")
+            Arg::with_name("rustfmt-bindings")
+                .long("rustfmt-bindings")
                 .help("Format the generated bindings with rustfmt. \
                        Rustfmt needs to be in the global PATH."),
-            Arg::with_name("format-configuration-file")
-                .long("format-configuration-file")
+            Arg::with_name("rustfmt-configuration-file")
+                .long("rustfmt-configuration-file")
                 .help("The absolute path to the rustfmt configuration file. \
-                       The configuration file will be used for formatting the bindings \
-                       (when enabled by --format-bindings).")
+                       The configuration file will be used for formatting the bindings. \
+                       Setting this parameter, will automatically set --rustfmt-bindings.")
                 .value_name("path")
                 .takes_value(true)
                 .multiple(false)
@@ -472,25 +472,25 @@ where
         builder.dump_preprocessed_input()?;
     }
 
-    if matches.is_present("format-bindings") {
-        builder = builder.format_bindings(true);
+    if matches.is_present("rustfmt-bindings") {
+        builder = builder.rustfmt_bindings(true);
     }
 
-    if let Some(path_str) = matches.value_of("format-configuration-file") {
+    if let Some(path_str) = matches.value_of("rustfmt-configuration-file") {
         let path = PathBuf::from(path_str);
 
         if !path.is_absolute() {
             return Err(Error::new(ErrorKind::Other,
-                                  "--format-configuration--file needs to be an absolute path!"));
+                                  "--rustfmt-configuration--file needs to be an absolute path!"));
         }
 
         if path.to_str().is_none() {
             return Err(
                 Error::new(ErrorKind::Other,
-                           "--format-configuration-file contains non-valid UTF8 characters."));
+                           "--rustfmt-configuration-file contains non-valid UTF8 characters."));
         }
 
-        builder = builder.format_configuration_file(Some(path));
+        builder = builder.rustfmt_configuration_file(Some(path));
     } 
 
     let verbose = matches.is_present("verbose");

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,6 +4,7 @@ use clap::{App, Arg};
 use std::fs::File;
 use std::io::{self, Error, ErrorKind, Write, stderr};
 use std::str::FromStr;
+use std::path::PathBuf;
 
 /// Construct a new [`Builder`](./struct.Builder.html) from command line flags.
 pub fn builder_from_flags<I>(
@@ -231,7 +232,20 @@ where
                 .help("Preprocess and dump the input header files to disk. \
                        Useful when debugging bindgen, using C-Reduce, or when \
                        filing issues. The resulting file will be named \
-                       something like `__bindgen.i` or `__bindgen.ii`.")
+                       something like `__bindgen.i` or `__bindgen.ii`."),
+            Arg::with_name("format-bindings")
+                .long("format-bindings")
+                .help("Format the generated bindings with rustfmt. \
+                       Rustfmt needs to be in the global PATH."),
+            Arg::with_name("format-configuration-file")
+                .long("format-configuration-file")
+                .help("The absolute path to the rustfmt configuration file. \
+                       The configuration file will be used for formatting the bindings \
+                       (when enabled by --format-bindings).")
+                .value_name("path")
+                .takes_value(true)
+                .multiple(false)
+                .number_of_values(1),
         ]) // .args()
         .get_matches_from(args);
 
@@ -457,6 +471,27 @@ where
     if matches.is_present("dump-preprocessed-input") {
         builder.dump_preprocessed_input()?;
     }
+
+    if matches.is_present("format-bindings") {
+        builder = builder.format_bindings(true);
+    }
+
+    if let Some(path_str) = matches.value_of("format-configuration-file") {
+        let path = PathBuf::from(path_str);
+
+        if !path.is_absolute() {
+            return Err(Error::new(ErrorKind::Other,
+                                  "--format-configuration--file needs to be an absolute path!"));
+        }
+
+        if path.to_str().is_none() {
+            return Err(
+                Error::new(ErrorKind::Other,
+                           "--format-configuration-file contains non-valid UTF8 characters."));
+        }
+
+        builder = builder.format_configuration_file(Some(path));
+    } 
 
     let verbose = matches.is_present("verbose");
 


### PR DESCRIPTION
This patch enables bindgen to run rustfmt on generated bindings. Rustfmt is used
from the global PATH. Two new command-line arguments are added:
1. --format-bindings: Enables running rustfmt
2. --format-configuration-file: The configuration file for rustfmt (not required).

Fixes: #900