### PR TITLE
Only include necessary files in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ documentation = "https://docs.rs/bindgen"
 version = "0.29.0"
 build = "build.rs"
 
-exclude = [
-  "bindgen-integration",
-  "ci",
-  "tests/**",
-  "*.orig",
+include = [
+  "Cargo.toml",
+  "build.rs",
+  "src/*.rs",
 ]
 
 [badges]


### PR DESCRIPTION
We now have various files that are unnecessary for package, including the book, the release note template, and even a 1.3MB PNG file!

This change makes us only include the necessary files (source files, build script, and metadata). Using whitelist so that we have fewer items, and it would be harder to regress.