### PR TITLE
Only compute which types we can derive PartialEq for if we'll use it

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1867,7 +1867,9 @@ impl<'ctx> BindgenContext<'ctx> {
     /// Compute whether we can derive hash.
     fn compute_cannot_derive_partialeq(&mut self) {
         assert!(self.cannot_derive_partialeq.is_none());
-        self.cannot_derive_partialeq = Some(analyze::<CannotDerivePartialEq>(self));
+        if self.options.derive_partialeq {
+            self.cannot_derive_partialeq = Some(analyze::<CannotDerivePartialEq>(self));
+        }
     }
 
     /// Look up whether the item with `id` can


### PR DESCRIPTION
If we aren't going to derive `PartialEq`, then it doesn't make sense to even run the analysis.

r? @photoszzt or @emilio 