### PR TITLE
Rewrite `has destructor` analysis as a fixed-point analysis

### DIFF
--- a/src/ir/analysis/derive_copy.rs
+++ b/src/ir/analysis/derive_copy.rs
@@ -208,7 +208,7 @@ impl<'ctx, 'gen> MonotoneFramework for CannotDeriveCopy<'ctx, 'gen> {
                 // NOTE: Take into account that while unions in C and C++ are copied by
                 // default, the may have an explicit destructor in C++, so we can't
                 // defer this check just for the union case.
-                if info.has_destructor(self.ctx) {
+                if self.ctx.lookup_item_id_has_destructor(&id) {
                     trace!("    comp has destructor which cannot derive copy");
                     return self.insert(id);
                 }

--- a/src/ir/analysis/has_destructor.rs
+++ b/src/ir/analysis/has_destructor.rs
@@ -1,0 +1,179 @@
+//! Determining which types have destructors
+
+use super::{ConstrainResult, MonotoneFramework, generate_dependencies};
+use ir::context::{BindgenContext, ItemId};
+use ir::traversal::EdgeKind;
+use ir::comp::{CompKind, Field, FieldMethods};
+use ir::ty::TypeKind;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+/// An analysis that finds for each IR item whether it has a destructor or not
+///
+/// We use the monotone function `has destructor`, defined as follows:
+///
+/// * If T is a type alias, a templated alias, or an indirection to another type,
+///   T has a destructor if the type T refers to has a destructor.
+/// * If T is a compound type, T has a destructor if we saw a destructor when parsing it,
+///   or if it's a struct, T has a destructor if any of its base members has a destructor,
+///   or if any of its fields have a destructor.
+/// * If T is an instantiation of an abstract template definition, T has
+///   a destructor if its template definition has a destructor,
+///   or if any of the template arguments has a destructor.
+/// * If T is the type of a field, that field has a destructor if it's not a bitfield,
+///   and if T has a destructor.
+#[derive(Debug, Clone)]
+pub struct HasDestructorAnalysis<'ctx, 'gen>
+where
+    'gen: 'ctx,
+{
+    ctx: &'ctx BindgenContext<'gen>,
+
+    // The incremental result of this analysis's computation. Everything in this
+    // set definitely has a destructor.
+    have_destructor: HashSet<ItemId>,
+
+    // Dependencies saying that if a key ItemId has been inserted into the
+    // `have_destructor` set, then each of the ids in Vec<ItemId> need to be
+    // considered again.
+    //
+    // This is a subset of the natural IR graph with reversed edges, where we
+    // only include the edges from the IR graph that can affect whether a type
+    // has a destructor or not.
+    dependencies: HashMap<ItemId, Vec<ItemId>>,
+}
+
+impl<'ctx, 'gen> HasDestructorAnalysis<'ctx, 'gen> {
+    fn consider_edge(kind: EdgeKind) -> bool {
+        match kind {
+            // These are the only edges that can affect whether a type has a
+            // destructor or not.
+            EdgeKind::TypeReference |
+            EdgeKind::BaseMember |
+            EdgeKind::Field |
+            EdgeKind::TemplateArgument |
+            EdgeKind::TemplateDeclaration => true,
+            _ => false,
+        }
+    }
+
+    fn insert(&mut self, id: ItemId) -> ConstrainResult {
+        let was_not_already_in_set = self.have_destructor.insert(id);
+        assert!(
+            was_not_already_in_set,
+            "We shouldn't try and insert {:?} twice because if it was \
+             already in the set, `constrain` should have exited early.",
+            id
+        );
+        ConstrainResult::Changed
+    }
+}
+
+impl<'ctx, 'gen> MonotoneFramework for HasDestructorAnalysis<'ctx, 'gen> {
+    type Node = ItemId;
+    type Extra = &'ctx BindgenContext<'gen>;
+    type Output = HashSet<ItemId>;
+
+    fn new(ctx: &'ctx BindgenContext<'gen>) -> Self {
+        let have_destructor = HashSet::new();
+        let dependencies = generate_dependencies(ctx, Self::consider_edge);
+
+        HasDestructorAnalysis {
+            ctx,
+            have_destructor,
+            dependencies,
+        }
+    }
+
+    fn initial_worklist(&self) -> Vec<ItemId> {
+        self.ctx.whitelisted_items().iter().cloned().collect()
+    }
+
+    fn constrain(&mut self, id: ItemId) -> ConstrainResult {
+        if self.have_destructor.contains(&id) {
+            // We've already computed that this type has a destructor and that can't
+            // change.
+            return ConstrainResult::Same;
+        }
+
+        let item = self.ctx.resolve_item(id);
+        let ty = match item.as_type() {
+            None => return ConstrainResult::Same,
+            Some(ty) => ty,
+        };
+
+        match *ty.kind() {
+            TypeKind::TemplateAlias(t, _) |
+            TypeKind::Alias(t) |
+            TypeKind::ResolvedTypeRef(t) => {
+                if self.have_destructor.contains(&t) {
+                    self.insert(id)
+                } else {
+                    ConstrainResult::Same
+                }
+            }
+
+            TypeKind::Comp(ref info) => {
+                if info.has_own_destructor() {
+                    return self.insert(id);
+                }
+
+                match info.kind() {
+                    CompKind::Union => ConstrainResult::Same,
+                    CompKind::Struct => {
+                        let base_or_field_destructor =
+                            info.base_members().iter().any(|base| {
+                                self.have_destructor.contains(&base.ty)
+                            }) ||
+                            info.fields().iter().any(|field| {
+                                match *field {
+                                    Field::DataMember(ref data) =>
+                                        self.have_destructor.contains(&data.ty()),
+                                    Field::Bitfields(_) => false
+                                }
+                            });
+                        if base_or_field_destructor {
+                            self.insert(id)
+                        } else {
+                            ConstrainResult::Same
+                        }
+                    }
+                }
+            }
+
+            TypeKind::TemplateInstantiation(ref inst) => {
+                let definition_or_arg_destructor =
+                    self.have_destructor.contains(&inst.template_definition())
+                    ||
+                    inst.template_arguments().iter().any(|arg| {
+                        self.have_destructor.contains(arg)
+                    });
+                if definition_or_arg_destructor {
+                    self.insert(id)
+                } else {
+                    ConstrainResult::Same
+                }
+            }
+
+            _ => ConstrainResult::Same,
+        }
+    }
+
+    fn each_depending_on<F>(&self, id: ItemId, mut f: F)
+    where
+        F: FnMut(ItemId),
+    {
+        if let Some(edges) = self.dependencies.get(&id) {
+            for item in edges {
+                trace!("enqueue {:?} into worklist", item);
+                f(*item);
+            }
+        }
+    }
+}
+
+impl<'ctx, 'gen> From<HasDestructorAnalysis<'ctx, 'gen>> for HashSet<ItemId> {
+    fn from(analysis: HasDestructorAnalysis<'ctx, 'gen>) -> Self {
+        analysis.have_destructor
+    }
+}

--- a/src/ir/analysis/mod.rs
+++ b/src/ir/analysis/mod.rs
@@ -45,6 +45,8 @@ pub use self::derive_debug::CannotDeriveDebug;
 mod has_vtable;
 pub use self::has_vtable::HasVtable;
 pub use self::has_vtable::HasVtableAnalysis;
+mod has_destructor;
+pub use self::has_destructor::HasDestructorAnalysis;
 mod derive_default;
 pub use self::derive_default::CannotDeriveDefault;
 mod derive_copy;

--- a/src/ir/template.rs
+++ b/src/ir/template.rs
@@ -309,14 +309,6 @@ impl TemplateInstantiation {
             template_args,
         ))
     }
-
-    /// Does this instantiation have a destructor?
-    pub fn has_destructor(&self, ctx: &BindgenContext) -> bool {
-        ctx.resolve_type(self.definition).has_destructor(ctx) ||
-            self.args.iter().any(|arg| {
-                ctx.resolve_type(*arg).has_destructor(ctx)
-            })
-    }
 }
 
 impl IsOpaque for TemplateInstantiation {

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -237,22 +237,6 @@ impl Type {
         })
     }
 
-    /// Returns whether this type has a destructor.
-    pub fn has_destructor(&self, ctx: &BindgenContext) -> bool {
-        match self.kind {
-            TypeKind::TemplateAlias(t, _) |
-            TypeKind::Alias(t) |
-            TypeKind::ResolvedTypeRef(t) => {
-                ctx.resolve_type(t).has_destructor(ctx)
-            }
-            TypeKind::TemplateInstantiation(ref inst) => {
-                inst.has_destructor(ctx)
-            }
-            TypeKind::Comp(ref info) => info.has_destructor(ctx),
-            _ => false,
-        }
-    }
-
     /// Whether this named type is an invalid C++ identifier. This is done to
     /// avoid generating invalid code with some cases we can't handle, see:
     ///


### PR DESCRIPTION
Fixes #927 . Note that this creates a dependency between the "cannot derive copy" and "has destructor" analysis, i.e. the "has destructor" analysis must run before the "cannot derive copy" analysis, because "cannot derive copy" needs the results of "has destructor".