### PR TITLE
Bump version to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bindgen"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.29.0"
+version = "0.30.0"
 build = "build.rs"
 
 include = [


### PR DESCRIPTION
Version bump, primarily to get #832 and #892 in now that 1.19 is out and untagged unions are usable in stable!

r? @emilio 