### PR TITLE
Depreciate whitelisted function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,9 +643,17 @@ impl Builder {
     /// Whitelist the given function so that it (and all types that it
     /// transitively refers to) appears in the generated bindings. Regular
     /// expressions are supported.
-    pub fn whitelisted_function<T: AsRef<str>>(mut self, arg: T) -> Builder {
+    pub fn whitelist_function<T: AsRef<str>>(mut self, arg: T) -> Builder {
         self.options.whitelisted_functions.insert(arg);
         self
+    }
+
+    /// Whitelist the given function.
+    ///
+    /// Deprecated: use whitelist_function instead.
+    #[deprecated = "use whitelist_function instead"]
+    pub fn whitelisted_function<T: AsRef<str>>(self, arg: T) -> Builder {
+        self.whitelist_function(arg)
     }
 
     /// Whitelist the given variable so that it (and all types that it

--- a/src/options.rs
+++ b/src/options.rs
@@ -473,7 +473,7 @@ where
 
     if let Some(whitelist) = matches.values_of("whitelist-function") {
         for regex in whitelist {
-            builder = builder.whitelisted_function(regex);
+            builder = builder.whitelist_function(regex);
         }
     }
 


### PR DESCRIPTION
Closes #985 

I also noticed a reference to `whitelisted_function` within the book, should this be updated as well?

https://github.com/rust-lang-nursery/rust-bindgen/blob/a371de097f5e37eb01754525fb1e2029ca88b0be/book/src/whitelisting.md

I've started to learn rust recently, so please let me know if there is anything I missed.

