### PR TITLE
Add a `Builder::blacklist_type`

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -321,7 +321,7 @@ impl CodeGenerator for Item {
             return;
         }
 
-        if self.is_hidden(ctx) || result.seen(self.id()) {
+        if self.is_blacklisted(ctx) || result.seen(self.id()) {
             debug!(
                 "<Item as CodeGenerator>::codegen: Ignoring hidden or seen: \
                  self = {:?}",

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -270,7 +270,7 @@ impl<'ctx> Iterator for WhitelistedItemsTraversal<'ctx> {
         loop {
             match self.traversal.next() {
                 None => return None,
-                Some(id) if self.ctx.resolve_item(id).is_hidden(self.ctx) => {
+                Some(id) if self.ctx.resolve_item(id).is_blacklisted(self.ctx) => {
                     continue
                 }
                 Some(id) => return Some(id),
@@ -1103,7 +1103,7 @@ impl BindgenContext {
             "We only compute template parameter usage as we enter codegen"
         );
 
-        if self.resolve_item(item).is_hidden(self) {
+        if self.resolve_item(item).is_blacklisted(self) {
             return true;
         }
 
@@ -1765,14 +1765,14 @@ impl BindgenContext {
         }
     }
 
-    /// Is the item with the given `name` hidden? Or is the item with the given
-    /// `name` and `id` replaced by another type, and effectively hidden?
-    pub fn hidden_by_name(&self, path: &[String], id: ItemId) -> bool {
+    /// Is the item with the given `name` blacklisted? Or is the item with the given
+    /// `name` and `id` replaced by another type, and effectively blacklisted?
+    pub fn blacklisted_by_name(&self, path: &[String], id: ItemId) -> bool {
         debug_assert!(
             self.in_codegen_phase(),
             "You're not supposed to call this yet"
         );
-        self.options.hidden_types.matches(&path[1..].join("::")) ||
+        self.options.blacklisted_types.matches(&path[1..].join("::")) ||
             self.is_replaced_type(path, id)
     }
 

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -603,16 +603,16 @@ impl Item {
         &self.annotations
     }
 
-    /// Whether this item should be hidden.
+    /// Whether this item should be blacklisted.
     ///
     /// This may be due to either annotations or to other kind of configuration.
-    pub fn is_hidden(&self, ctx: &BindgenContext) -> bool {
+    pub fn is_blacklisted(&self, ctx: &BindgenContext) -> bool {
         debug_assert!(
             ctx.in_codegen_phase(),
             "You're not supposed to call this yet"
         );
         self.annotations.hide() ||
-            ctx.hidden_by_name(&self.canonical_path(ctx), self.id)
+            ctx.blacklisted_by_name(&self.canonical_path(ctx), self.id)
     }
 
     /// Is this a reference to another type?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ impl Builder {
             .count();
 
         self.options
-            .hidden_types
+            .blacklisted_types
             .get_items()
             .iter()
             .map(|item| {
@@ -620,8 +620,15 @@ impl Builder {
 
     /// Hide the given type from the generated bindings. Regular expressions are
     /// supported.
-    pub fn hide_type<T: AsRef<str>>(mut self, arg: T) -> Builder {
-        self.options.hidden_types.insert(arg);
+    #[deprecated = "Use blacklist_type instead"]
+    pub fn hide_type<T: AsRef<str>>(self, arg: T) -> Builder {
+        self.blacklist_type(arg)
+    }
+
+    /// Hide the given type from the generated bindings. Regular expressions are
+    /// supported.
+    pub fn blacklist_type<T: AsRef<str>>(mut self, arg: T) -> Builder {
+        self.options.blacklisted_types.insert(arg);
         self
     }
 
@@ -1085,7 +1092,7 @@ impl Builder {
 pub struct BindgenOptions {
     /// The set of types that have been blacklisted and should not appear
     /// anywhere in the generated code.
-    pub hidden_types: RegexSet,
+    pub blacklisted_types: RegexSet,
 
     /// The set of types that should be treated as opaque structures in the
     /// generated code.
@@ -1261,7 +1268,7 @@ impl BindgenOptions {
         self.whitelisted_vars.build();
         self.whitelisted_types.build();
         self.whitelisted_functions.build();
-        self.hidden_types.build();
+        self.blacklisted_types.build();
         self.opaque_types.build();
         self.bitfield_enums.build();
         self.constified_enum_modules.build();
@@ -1294,7 +1301,7 @@ impl Default for BindgenOptions {
         BindgenOptions {
             rust_target: rust_target,
             rust_features: rust_target.into(),
-            hidden_types: Default::default(),
+            blacklisted_types: Default::default(),
             opaque_types: Default::default(),
             whitelisted_types: Default::default(),
             whitelisted_functions: Default::default(),


### PR DESCRIPTION
This deprecates `Builder::hide_type`.
Related to #984.

- [x] Add Builder::blacklist_type, that does the same thing as hide_type
- [x] Mark Builder::hide_type as #[deprecated = "Use blacklist_type instead"]
- [x] Make hide_type delegate to blacklist_type
- [x] Rename the BindgenOptions::hidden_types member to BindgenOptions::blacklisted_types
- [x] Rename ir::context::BindgenContext::hidden_by_name to blacklisted_by_name
- [x] Rename ir::item::Item::is_hidden to is_blacklisted

r? @fitzgen 