### PR TITLE
Fix whitelisting documentation links in book.

### DIFF
--- a/book/src/whitelisting.md
+++ b/book/src/whitelisting.md
@@ -16,9 +16,9 @@ transitively used by a definition that matches them.
 
 ### Library
 
-* [`bindgen::Builder::whitelisted_type`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelisted_type)
-* [`bindgen::Builder::whitelisted_function`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelisted_function)
-* [`bindgen::Builder::whitelisted_var`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelisted_function)
+* [`bindgen::Builder::whitelist_type`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelist_type)
+* [`bindgen::Builder::whitelist_function`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelist_function)
+* [`bindgen::Builder::whitelist_var`](https://docs.rs/bindgen/0.23.1/bindgen/struct.Builder.html#method.whitelist_var)
 
 ### Command Line
 


### PR DESCRIPTION
While working on #990 depreciated the `whitelisted_function` I noticed a couple of links in the book that also should be updated to refer to the updated methods.

@fitzgen one question here, I assume I will also need to update the version number within the url as new documentation won't be built until the next release? 