### PR TITLE
Depreciate `Builder::whitelisted_type`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,7 +642,15 @@ impl Builder {
     /// Whitelist the given type so that it (and all types that it transitively
     /// refers to) appears in the generated bindings. Regular expressions are
     /// supported.
-    pub fn whitelisted_type<T: AsRef<str>>(mut self, arg: T) -> Builder {
+    #[deprecated = "use whitelist_type instead"]
+    pub fn whitelisted_type<T: AsRef<str>>(self, arg: T) -> Builder {
+        self.whitelist_type(arg)
+    }
+
+    /// Whitelist the given type so that it (and all types that it transitively
+    /// refers to) appears in the generated bindings. Regular expressions are
+    /// supported.
+    pub fn whitelist_type<T: AsRef<str>>(mut self, arg: T) -> Builder {
         self.options.whitelisted_types.insert(arg);
         self
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -304,7 +304,7 @@ where
     }
     if let Some(hidden_types) = matches.values_of("blacklist-type") {
         for ty in hidden_types {
-            builder = builder.hide_type(ty);
+            builder = builder.blacklist_type(ty);
         }
     }
 
@@ -479,7 +479,7 @@ where
 
     if let Some(whitelist) = matches.values_of("whitelist-type") {
         for regex in whitelist {
-            builder = builder.whitelisted_type(regex);
+            builder = builder.whitelist_type(regex);
         }
     }
 


### PR DESCRIPTION
Closes #987

Also, we were making a call to the now deprecated `Builder::hide_type`,
changed that over to call `Builder::blacklist_type.