### PR TITLE
codegen: Use _ instead of argN for unnamed arguments.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3645,7 +3645,6 @@ mod utils {
     ) -> Vec<quote::Tokens> {
         use super::ToPtr;
 
-        let mut unnamed_arguments = 0;
         sig.argument_types().iter().map(|&(ref name, ty)| {
             let arg_item = ctx.resolve_item(ty);
             let arg_ty = arg_item.kind().expect_type();
@@ -3680,11 +3679,8 @@ mod utils {
             };
 
             let arg_name = match *name {
-                Some(ref name) => ctx.rust_mangle(name).into_owned(),
-                None => {
-                    unnamed_arguments += 1;
-                    format!("arg{}", unnamed_arguments)
-                }
+                Some(ref name) => ctx.rust_mangle(name),
+                None => "_".into(),
             };
 
             assert!(!arg_name.is_empty());

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -5,5 +5,5 @@
 
 
 extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void);
+    pub fn atexit_b(_: *mut ::std::os::raw::c_void);
 }

--- a/tests/expectations/tests/canonical_path_without_namespacing.rs
+++ b/tests/expectations/tests/canonical_path_without_namespacing.rs
@@ -11,15 +11,23 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
-    assert_eq!(::std::mem::size_of::<Bar>() , 1usize , concat ! (
-               "Size of: " , stringify ! ( Bar ) ));
-    assert_eq! (::std::mem::align_of::<Bar>() , 1usize , concat ! (
-                "Alignment of " , stringify ! ( Bar ) ));
+    assert_eq!(
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar))
+    );
 }
 impl Clone for Bar {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 extern "C" {
     #[link_name = "_Z3bazPN3foo3BarE"]
-    pub fn baz(arg1: *mut Bar);
+    pub fn baz(_: *mut Bar);
 }

--- a/tests/expectations/tests/constructors.rs
+++ b/tests/expectations/tests/constructors.rs
@@ -11,32 +11,39 @@ pub struct TestOverload {
 }
 #[test]
 fn bindgen_test_layout_TestOverload() {
-    assert_eq!(::std::mem::size_of::<TestOverload>() , 1usize , concat ! (
-               "Size of: " , stringify ! ( TestOverload ) ));
-    assert_eq! (::std::mem::align_of::<TestOverload>() , 1usize , concat ! (
-                "Alignment of " , stringify ! ( TestOverload ) ));
+    assert_eq!(
+        ::std::mem::size_of::<TestOverload>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestOverload))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<TestOverload>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestOverload))
+    );
 }
 extern "C" {
     #[link_name = "_ZN12TestOverloadC1Ei"]
-    pub fn TestOverload_TestOverload(this: *mut TestOverload,
-                                     arg1: ::std::os::raw::c_int);
+    pub fn TestOverload_TestOverload(this: *mut TestOverload, _: ::std::os::raw::c_int);
 }
 extern "C" {
     #[link_name = "_ZN12TestOverloadC1Ed"]
-    pub fn TestOverload_TestOverload1(this: *mut TestOverload, arg1: f64);
+    pub fn TestOverload_TestOverload1(this: *mut TestOverload, _: f64);
 }
 impl Clone for TestOverload {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl TestOverload {
     #[inline]
-    pub unsafe fn new(arg1: ::std::os::raw::c_int) -> Self {
+    pub unsafe fn new(_: ::std::os::raw::c_int) -> Self {
         let mut __bindgen_tmp = ::std::mem::uninitialized();
         TestOverload_TestOverload(&mut __bindgen_tmp, arg1);
         __bindgen_tmp
     }
     #[inline]
-    pub unsafe fn new1(arg1: f64) -> Self {
+    pub unsafe fn new1(_: f64) -> Self {
         let mut __bindgen_tmp = ::std::mem::uninitialized();
         TestOverload_TestOverload1(&mut __bindgen_tmp, arg1);
         __bindgen_tmp
@@ -49,17 +56,25 @@ pub struct TestPublicNoArgs {
 }
 #[test]
 fn bindgen_test_layout_TestPublicNoArgs() {
-    assert_eq!(::std::mem::size_of::<TestPublicNoArgs>() , 1usize , concat ! (
-               "Size of: " , stringify ! ( TestPublicNoArgs ) ));
-    assert_eq! (::std::mem::align_of::<TestPublicNoArgs>() , 1usize , concat !
-                ( "Alignment of " , stringify ! ( TestPublicNoArgs ) ));
+    assert_eq!(
+        ::std::mem::size_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestPublicNoArgs))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestPublicNoArgs))
+    );
 }
 extern "C" {
     #[link_name = "_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);
 }
 impl Clone for TestPublicNoArgs {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl TestPublicNoArgs {
     #[inline]

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -4,23 +4,26 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
 
-pub type my_fun_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int,
-                                               arg2: ::std::os::raw::c_int,
-                                               arg3: ::std::os::raw::c_int,
-                                               arg4: ::std::os::raw::c_int,
-                                               arg5: ::std::os::raw::c_int,
-                                               arg6: ::std::os::raw::c_int,
-                                               arg7: ::std::os::raw::c_int,
-                                               arg8: ::std::os::raw::c_int,
-                                               arg9: ::std::os::raw::c_int,
-                                               arg10: ::std::os::raw::c_int,
-                                               arg11: ::std::os::raw::c_int,
-                                               arg12: ::std::os::raw::c_int,
-                                               arg13: ::std::os::raw::c_int,
-                                               arg14: ::std::os::raw::c_int,
-                                               arg15: ::std::os::raw::c_int,
-                                               arg16: ::std::os::raw::c_int)>;
+pub type my_fun_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+    ),
+>;
 #[repr(C)]
 #[derive(Copy)]
 pub struct Foo {
@@ -28,35 +31,53 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
-    assert_eq!(::std::mem::size_of::<Foo>() , 8usize , concat ! (
-               "Size of: " , stringify ! ( Foo ) ));
-    assert_eq! (::std::mem::align_of::<Foo>() , 8usize , concat ! (
-                "Alignment of " , stringify ! ( Foo ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const Foo ) ) . callback as * const _ as usize
-                } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( Foo ) , "::" ,
-                stringify ! ( callback ) ));
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo))
+    );
+    assert_eq!(
+        unsafe { &(*(0 as *const Foo)).callback as *const _ as usize },
+        0usize,
+        concat!(
+            "Alignment of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(callback)
+        )
+    );
 }
 impl Clone for Foo {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl Default for Foo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
-pub type my_fun2_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int,
-                                               arg2: ::std::os::raw::c_int,
-                                               arg3: ::std::os::raw::c_int,
-                                               arg4: ::std::os::raw::c_int,
-                                               arg5: ::std::os::raw::c_int,
-                                               arg6: ::std::os::raw::c_int,
-                                               arg7: ::std::os::raw::c_int,
-                                               arg8: ::std::os::raw::c_int,
-                                               arg9: ::std::os::raw::c_int,
-                                               arg10: ::std::os::raw::c_int,
-                                               arg11: ::std::os::raw::c_int,
-                                               arg12: ::std::os::raw::c_int)>;
+pub type my_fun2_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+        _: ::std::os::raw::c_int,
+    ),
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Hash, PartialEq, Eq)]
 pub struct Bar {
@@ -64,19 +85,34 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
-    assert_eq!(::std::mem::size_of::<Bar>() , 8usize , concat ! (
-               "Size of: " , stringify ! ( Bar ) ));
-    assert_eq! (::std::mem::align_of::<Bar>() , 8usize , concat ! (
-                "Alignment of " , stringify ! ( Bar ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const Bar ) ) . callback as * const _ as usize
-                } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( Bar ) , "::" ,
-                stringify ! ( callback ) ));
+    assert_eq!(
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar))
+    );
+    assert_eq!(
+        unsafe { &(*(0 as *const Bar)).callback as *const _ as usize },
+        0usize,
+        concat!(
+            "Alignment of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(callback)
+        )
+    );
 }
 impl Clone for Bar {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl Default for Bar {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }

--- a/tests/expectations/tests/issue-410.rs
+++ b/tests/expectations/tests/issue-410.rs
@@ -30,8 +30,8 @@ pub mod root {
             );
         }
         extern "C" {
-    #[link_name = "_ZN2JS5Value1aE10JSWhyMagic"]
-            pub fn Value_a(this: *mut root::JS::Value, arg1: root::JSWhyMagic);
+            #[link_name = "_ZN2JS5Value1aE10JSWhyMagic"]
+            pub fn Value_a(this: *mut root::JS::Value, _: root::JSWhyMagic);
         }
         impl Clone for Value {
             fn clone(&self) -> Self {
@@ -40,11 +40,11 @@ pub mod root {
         }
         impl Value {
             #[inline]
-            pub unsafe fn a(&mut self, arg1: root::JSWhyMagic) {
+            pub unsafe fn a(&mut self, _: root::JSWhyMagic) {
                 Value_a(self, arg1)
             }
         }
     }
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub enum JSWhyMagic { }
+    pub enum JSWhyMagic {}
 }

--- a/tests/expectations/tests/issue-447.rs
+++ b/tests/expectations/tests/issue-447.rs
@@ -58,10 +58,10 @@ pub mod root {
         );
     }
     extern "C" {
-    #[link_name = "_ZN17JSAutoCompartmentC1EN7mozilla6detail19GuardObjectNotifierE"]
+        #[link_name = "_ZN17JSAutoCompartmentC1EN7mozilla6detail19GuardObjectNotifierE"]
         pub fn JSAutoCompartment_JSAutoCompartment(
             this: *mut root::JSAutoCompartment,
-            arg1: root::mozilla::detail::GuardObjectNotifier,
+            _: root::mozilla::detail::GuardObjectNotifier,
         );
     }
     impl Clone for JSAutoCompartment {
@@ -71,7 +71,7 @@ pub mod root {
     }
     impl JSAutoCompartment {
         #[inline]
-        pub unsafe fn new(arg1: root::mozilla::detail::GuardObjectNotifier) -> Self {
+        pub unsafe fn new(_: root::mozilla::detail::GuardObjectNotifier) -> Self {
             let mut __bindgen_tmp = ::std::mem::uninitialized();
             JSAutoCompartment_JSAutoCompartment(&mut __bindgen_tmp, arg1);
             __bindgen_tmp

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -80,32 +80,32 @@ pub struct cmdline_token_ops {
     /// parse(token ptr, buf, res pts, buf len)
     pub parse: ::std::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cmdline_parse_token_hdr_t,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: *mut ::std::os::raw::c_void,
-            arg4: ::std::os::raw::c_uint,
+            _: *mut cmdline_parse_token_hdr_t,
+            _: *const ::std::os::raw::c_char,
+            _: *mut ::std::os::raw::c_void,
+            _: ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
     /// return the num of possible choices for this token
     pub complete_get_nb: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut cmdline_parse_token_hdr_t)
+        unsafe extern "C" fn(_: *mut cmdline_parse_token_hdr_t)
             -> ::std::os::raw::c_int,
     >,
     /// return the elt x for this token (token, idx, dstbuf, size)
     pub complete_get_elt: ::std::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cmdline_parse_token_hdr_t,
-            arg2: ::std::os::raw::c_int,
-            arg3: *mut ::std::os::raw::c_char,
-            arg4: ::std::os::raw::c_uint,
+            _: *mut cmdline_parse_token_hdr_t,
+            _: ::std::os::raw::c_int,
+            _: *mut ::std::os::raw::c_char,
+            _: ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
     /// get help for this token (token, dstbuf, size)
     pub get_help: ::std::option::Option<
         unsafe extern "C" fn(
-            arg1: *mut cmdline_parse_token_hdr_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_uint,
+            _: *mut cmdline_parse_token_hdr_t,
+            _: *mut ::std::os::raw::c_char,
+            _: ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
 }

--- a/tests/expectations/tests/template-fun-ty.rs
+++ b/tests/expectations/tests/template-fun-ty.rs
@@ -9,8 +9,7 @@
 pub struct Foo {
     pub _address: u8,
 }
-pub type Foo_FunctionPtr<T> =
-    ::std::option::Option<unsafe extern "C" fn() -> T>;
+pub type Foo_FunctionPtr<T> = ::std::option::Option<unsafe extern "C" fn() -> T>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct RefPtr {
@@ -21,6 +20,7 @@ pub struct RefPtr {
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }
-pub type RefPtr_Proxy_member_function<R, Args> =
-    ::std::option::Option<unsafe extern "C" fn(arg1: Args) -> R>;
+pub type RefPtr_Proxy_member_function<R, Args> = ::std::option::Option<
+    unsafe extern "C" fn(_: Args) -> R,
+>;
 pub type Returner<T> = ::std::option::Option<unsafe extern "C" fn() -> T>;

--- a/tests/expectations/tests/template_typedefs.rs
+++ b/tests/expectations/tests/template_typedefs.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
 
-pub type foo = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type foo = ::std::option::Option<unsafe extern "C" fn(_: ::std::os::raw::c_int)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {

--- a/tests/expectations/tests/type-referenced-by-whitelisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-whitelisted-function.rs
@@ -11,19 +11,32 @@ pub struct dl_phdr_info {
 }
 #[test]
 fn bindgen_test_layout_dl_phdr_info() {
-    assert_eq!(::std::mem::size_of::<dl_phdr_info>() , 4usize , concat ! (
-               "Size of: " , stringify ! ( dl_phdr_info ) ));
-    assert_eq! (::std::mem::align_of::<dl_phdr_info>() , 4usize , concat ! (
-                "Alignment of " , stringify ! ( dl_phdr_info ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const dl_phdr_info ) ) . x as * const _ as
-                usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( dl_phdr_info ) , "::" ,
-                stringify ! ( x ) ));
+    assert_eq!(
+        ::std::mem::size_of::<dl_phdr_info>(),
+        4usize,
+        concat!("Size of: ", stringify!(dl_phdr_info))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<dl_phdr_info>(),
+        4usize,
+        concat!("Alignment of ", stringify!(dl_phdr_info))
+    );
+    assert_eq!(
+        unsafe { &(*(0 as *const dl_phdr_info)).x as *const _ as usize },
+        0usize,
+        concat!(
+            "Alignment of field: ",
+            stringify!(dl_phdr_info),
+            "::",
+            stringify!(x)
+        )
+    );
 }
 impl Clone for dl_phdr_info {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 extern "C" {
-    pub fn dl_iterate_phdr(arg1: *mut dl_phdr_info) -> ::std::os::raw::c_int;
+    pub fn dl_iterate_phdr(_: *mut dl_phdr_info) -> ::std::os::raw::c_int;
 }

--- a/tests/expectations/tests/virtual_overloaded.rs
+++ b/tests/expectations/tests/virtual_overloaded.rs
@@ -13,24 +13,32 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
-    assert_eq!(::std::mem::size_of::<C>() , 8usize , concat ! (
-               "Size of: " , stringify ! ( C ) ));
-    assert_eq! (::std::mem::align_of::<C>() , 8usize , concat ! (
-                "Alignment of " , stringify ! ( C ) ));
+    assert_eq!(
+        ::std::mem::size_of::<C>(),
+        8usize,
+        concat!("Size of: ", stringify!(C))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C))
+    );
 }
 impl Clone for C {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl Default for C {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 extern "C" {
     #[link_name = "_ZN1C8do_thingEc"]
-    pub fn C_do_thing(this: *mut ::std::os::raw::c_void,
-                      arg1: ::std::os::raw::c_char);
+    pub fn C_do_thing(this: *mut ::std::os::raw::c_void, _: ::std::os::raw::c_char);
 }
 extern "C" {
     #[link_name = "_ZN1C8do_thingEi"]
-    pub fn C_do_thing1(this: *mut ::std::os::raw::c_void,
-                       arg1: ::std::os::raw::c_int);
+    pub fn C_do_thing1(this: *mut ::std::os::raw::c_void, _: ::std::os::raw::c_int);
 }


### PR DESCRIPTION
Less code, more fun.