### PR TITLE
Always check out test headers and expectations as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 tests/stylo.hpp -diff
+tests/headers/* eol=lf
+tests/expectations/tests/* eol=lf


### PR DESCRIPTION
Addresses #1023.

The line endings accidentally don't matter for the majority of the tests because we pass both the generated .rs files and expectations .rs files through rustfmt, which normalizes the line endings to LF. But this change makes it explicit that we expect to test against files with LF line endings.