### PR TITLE
Make objc-related expectations compile

### DIFF
--- a/src/ir/objc.rs
+++ b/src/ir/objc.rs
@@ -236,13 +236,21 @@ impl ObjCMethod {
             );
         }
 
+        // Get arguments without type signatures to pass to `msg_send!`
+        let mut args_without_types = vec![];
+        for arg in args.iter() {
+            let name_and_sig: Vec<&str> = arg.as_str().split(' ').collect();
+            let name = name_and_sig[0];
+            args_without_types.push(quote::Ident::new(name))
+        };
+
         let args = split_name
             .into_iter()
-            .zip(args.iter())
-            .map(|(arg, ty)| quote! { #arg : #ty });
+            .zip(args_without_types)
+            .map(|(arg, arg_val)| quote! { #arg : #arg_val });
 
         quote! {
-            #( #args ),*
+            #( #args )*
         }
     }
 }

--- a/tests/expectations/tests/objc_class_method.rs
+++ b/tests/expectations/tests/objc_class_method.rs
@@ -30,13 +30,13 @@ impl Foo for id {
     unsafe fn methodWithInt_(foo: ::std::os::raw::c_int) {
         msg_send!(
             objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodWithInt: foo: ::std::os::raw::c_int
+            methodWithInt: foo
         )
     }
     unsafe fn methodWithFoo_(foo: id) {
         msg_send!(
             objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodWithFoo: foo: id
+            methodWithFoo: foo
         )
     }
     unsafe fn methodReturningInt() -> ::std::os::raw::c_int {
@@ -56,11 +56,6 @@ impl Foo for id {
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
     ) {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodWithArg1: intvalue: ::std::os::raw::c_int,
-            andArg2: ptr: *mut ::std::os::raw::c_char,
-            andArg3: floatvalue: f32
-        )
+        msg_send ! ( objc :: runtime :: Class :: get ( "Foo" ) . expect ( "Couldn't find Foo" ) , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
 }

--- a/tests/expectations/tests/objc_method.rs
+++ b/tests/expectations/tests/objc_method.rs
@@ -26,10 +26,10 @@ impl Foo for id {
         msg_send!(self, method)
     }
     unsafe fn methodWithInt_(self, foo: ::std::os::raw::c_int) {
-        msg_send!(self, methodWithInt: foo: ::std::os::raw::c_int)
+        msg_send!(self, methodWithInt: foo)
     }
     unsafe fn methodWithFoo_(self, foo: id) {
-        msg_send!(self, methodWithFoo: foo: id)
+        msg_send!(self, methodWithFoo: foo)
     }
     unsafe fn methodReturningInt(self) -> ::std::os::raw::c_int {
         msg_send!(self, methodReturningInt)
@@ -43,11 +43,6 @@ impl Foo for id {
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
     ) {
-        msg_send!(
-            self,
-            methodWithArg1: intvalue: ::std::os::raw::c_int,
-            andArg2: ptr: *mut ::std::os::raw::c_char,
-            andArg3: floatvalue: f32
-        )
+        msg_send ! ( self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
 }

--- a/tests/expectations/tests/objc_property_fnptr.rs
+++ b/tests/expectations/tests/objc_property_fnptr.rs
@@ -23,9 +23,6 @@ impl Foo for id {
         self,
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>,
     ) {
-        msg_send!(
-            self,
-            setFunc: func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>
-        )
+        msg_send!(self, setFunc: func)
     }
 }


### PR DESCRIPTION
Fixes #1004.

After looking at how `msg_send!` is supposed to be used, I realized that
we were erroneously passing type signatures to it.

The expectations compile now, but some of them are not formatted properly.
My guess is that `rustfmt` does not know how to format the following:

```
msg_send!(obj, arg1:1 arg2:2 arg3:3)
```

Notice the lack of separatros between the `arg`s.

Any advice on how to proceed here is appreciated.

r? @fitzgen 