### PR TITLE
csmith fuzzing

### DIFF
--- a/csmith-fuzzing/README
+++ b/csmith-fuzzing/README
@@ -1,0 +1,7 @@
+Fuzz bindgen with `csmith` https://github.com/csmith-project/csmith .
+
+Run with `python3 driver.py`. It will run until until it encounters an error in `bindgen`.
+
+Requires `python3`, `csmith` and `bindgen` to be in `$PATH`.
+
+csmith is run with `--no-checksum --nomain --max-block-size 1 --max-block-depth 1` which disables the `main` function and makes function bodies as simple as possible as bindgen does not care about them but they cannot be completely disabled in csmith. Run `csmith --help` to see what exactly those options do.

--- a/csmith-fuzzing/csmith.h
+++ b/csmith-fuzzing/csmith.h
@@ -1,0 +1,15 @@
+// Type definitions from csmith's csmith_minimal.h included in csmith.h .
+// Since other header contents are not needed we put them in here
+// so the other original header is not needed anymore.
+
+#define int8_t signed char
+#define uint8_t unsigned char
+
+#define int16_t short
+#define uint16_t unsigned short
+
+#define int32_t int
+#define uint32_t unsigned
+
+#define int64_t long long
+#define uint64_t unsigned long long

--- a/csmith-fuzzing/driver.py
+++ b/csmith-fuzzing/driver.py
@@ -1,0 +1,33 @@
+from subprocess import run, DEVNULL, PIPE
+
+csmith_command = [
+        "csmith",
+        "--no-checksum",
+        "--nomain",
+        "--max-block-size", "1",
+        "--max-block-depth", "1",
+        "--output", "generated.h"]
+
+bindgen_command = ["bindgen", "generated.h"]
+
+if __name__ == "__main__":
+    print("Bindgen fuzzing with csmith.")
+    print(
+        "This script will write to generated.h, bindgen_stdout, bindgen_stderr and platform.info . "
+        "These files can be deleted after running.")
+
+    iterations = 0
+    while True:
+        print("\rIteration: {}".format(iterations), end="", flush=True)
+
+        run(csmith_command, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
+        with open("bindgen_stdout", "wb") as stdout, open("bindgen_stdout", "wb") as stderr:
+            result = run(bindgen_command, stdin=DEVNULL, stdout=stdout, stderr=stderr)
+            if result.returncode != 0:
+                print()
+                print(
+                    "Error: bindgen existed with non zero exit code {} when ran on generated.h . "
+                    "You can find its output in bindgen_stoud and bindgen_stderr."
+                    .format(result.returncode))
+                exit()
+        iterations += 1


### PR DESCRIPTION
ref #969 

An initial version of a script that fuzzes bindgen with csmith. I ran it for maybe 1000 iterations and it did not find something wrong. The programs generated by csmith are probably too simple type wise.

Here is an example output of what csmith generates:
``` C
/* --- Struct/Union Declarations --- */
union U2 {
   uint64_t  f0;
   const signed f1 : 18;
};

union U4 {
   const volatile signed f0 : 1;
   volatile int16_t  f1;
   int32_t  f2;
   int8_t * const  f3;
   volatile int64_t  f4;
};

union U5 {
   const int8_t * f0;
   volatile int8_t  f1;
   uint16_t  f2;
   unsigned f3 : 22;
};

/* --- GLOBAL VARIABLES --- */
static int8_t g_3[8] = {0x47L,0xE8L,0x47L,0x47L,0xE8L,0x47L,0x47L,0xE8L};
static int32_t g_25 = 0x3421AD7BL;
static union U5 g_40 = {0};/* VOLATILE GLOBAL g_40 */
static int32_t g_43[4][3] = {{(-10L),(-10L),(-10L)},{(-10L),(-10L),(-10L)},{(-10L),(-10L),(-10L)},{(-10L),($static int32_t * volatile g_42 = &g_43[0][0];/* VOLATILE GLOBAL g_42 */
static int32_t * volatile g_50 = &g_43[2][0];/* VOLATILE GLOBAL g_50 */
static int32_t g_53 = (-9L);
static union U4 g_57 = {0x9C113E7BL};/* VOLATILE GLOBAL g_57 */


/* --- FORWARD DECLARATIONS --- */
static union U4  func_1(void);
static int16_t  func_4(int32_t  p_5);
static int32_t  func_6(int32_t  p_7, union U2  p_8, int8_t * p_9);
static int32_t  func_10(uint32_t  p_11, int8_t * p_12, int8_t * p_13);
static int8_t * func_14(int32_t  p_15, union U2  p_16);
static union U2  func_28(const uint64_t  p_29, int8_t * p_30, uint32_t  p_31);
static union U5  func_34(uint32_t  p_35);
```