### PR TITLE
Remove early anonymous bitfield filtering and consolidate name method

### DIFF
--- a/src/codegen/impl_debug.rs
+++ b/src/codegen/impl_debug.rs
@@ -95,11 +95,14 @@ impl<'a> ImplDebug<'a> for BitfieldUnit {
             if i > 0 {
                 format_string.push_str(", ");
             }
-            format_string.push_str(&format!("{} : {{:?}}", bu.name()));
-            let name_ident = ctx.rust_ident_raw(bu.name());
-            tokens.push(quote! {
-                self.#name_ident ()
-            });
+
+            if let Some(name) = bu.name() {
+                format_string.push_str(&format!("{} : {{:?}}", name));
+                let name_ident = ctx.rust_ident_raw(name);
+                tokens.push(quote! {
+                    self.#name_ident ()
+                });
+            }
         }
 
         Some((format_string, tokens))

--- a/src/codegen/impl_partialeq.rs
+++ b/src/codegen/impl_partialeq.rs
@@ -51,10 +51,12 @@ pub fn gen_partialeq_impl(
                     tokens.push(gen_field(ctx, ty_item, name));
                 }
                 Field::Bitfields(ref bu) => for bitfield in bu.bitfields() {
-                    let name_ident = ctx.rust_ident_raw(bitfield.name());
-                    tokens.push(quote! {
-                        self.#name_ident () == other.#name_ident ()
-                    });
+                    if let Some(name) = bitfield.name() {
+                        let name_ident = ctx.rust_ident_raw(name);
+                        tokens.push(quote! {
+                            self.#name_ident () == other.#name_ident ()
+                        });
+                    }
                 },
             }
         }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1185,6 +1185,10 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
         let mut ctor_impl = quote! { 0 };
 
         for bf in self.bitfields() {
+            // Codegen not allowed for anonymous bitfields
+            if bf.name().is_none() {
+                continue;
+            }
             bf.codegen(
                 ctx,
                 fields_should_be_private,
@@ -1198,7 +1202,7 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
                 (&unit_field_name, unit_field_int_ty.clone()),
             );
 
-            let param_name = bitfield_getter_name(ctx, parent, bf.name());
+            let param_name = bitfield_getter_name(ctx, parent, bf.name().unwrap());
             let bitfield_ty_item = ctx.resolve_item(bf.ty());
             let bitfield_ty = bitfield_ty_item.expect_type();
             let bitfield_ty =
@@ -1307,9 +1311,11 @@ impl<'a> FieldCodegen<'a> for Bitfield {
         F: Extend<quote::Tokens>,
         M: Extend<quote::Tokens>,
     {
+        // Should never be called with name() as None, as codegen can't be done
+        // on an anonymous bitfield
         let prefix = ctx.trait_prefix();
-        let getter_name = bitfield_getter_name(ctx, parent, self.name());
-        let setter_name = bitfield_setter_name(ctx, parent, self.name());
+        let getter_name = bitfield_getter_name(ctx, parent, self.name().unwrap());
+        let setter_name = bitfield_setter_name(ctx, parent, self.name().unwrap());
         let unit_field_ident = quote::Ident::new(unit_field_name);
 
         let bitfield_ty_item = ctx.resolve_item(self.ty());

--- a/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/tests/expectations/tests/bitfield_large_overflow.rs
@@ -18,4 +18,3 @@ extern "C" {
     #[link_name = "a"]
     pub static mut a: _bindgen_ty_1;
 }
-


### PR DESCRIPTION
This PR is some changes to early bitfield filtering to help fix (#1007) This does not close (#1007), but allows for checking if the bitfield is too large during a later stage.

@fitzgen r?