### PR TITLE
Make bitfields larger than type opaque

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1137,8 +1137,6 @@ impl BindgenContext {
     {
         self.in_codegen = true;
 
-        self.assert_no_dangling_references();
-
         if !self.collected_typerefs() {
             self.resolve_typerefs();
             self.compute_bitfield_units();
@@ -1147,8 +1145,6 @@ impl BindgenContext {
 
         self.deanonymize_fields();
 
-        // And assert once again, because resolving type refs and processing
-        // replacements both mutate the IR graph.
         self.assert_no_dangling_references();
 
         // Compute the whitelisted set after processing replacements and

--- a/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/tests/expectations/tests/bitfield_large_overflow.rs
@@ -5,13 +5,26 @@
 
 
 #[repr(C)]
+#[derive(Debug, Default, Copy)]
 pub struct _bindgen_ty_1 {
-    pub _bitfield_1: [u8; 128usize],
-    pub __bindgen_align: [u64; 0usize],
+    pub _bindgen_opaque_blob: [u64; 10usize],
 }
-impl Default for _bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+#[test]
+fn bindgen_test_layout__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<_bindgen_ty_1>(),
+        80usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1))
+    );
+}
+impl Clone for _bindgen_ty_1 {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 extern "C" {

--- a/tests/headers/bitfield_large_overflow.hpp
+++ b/tests/headers/bitfield_large_overflow.hpp
@@ -1,5 +1,3 @@
-// bindgen-flags: --no-layout-tests
-
 struct {
   unsigned : 632;
 } a;


### PR DESCRIPTION
@fitzgen r?

Fixes #1007 by ensuring that bitfields larger than type will be opaque, ensuring the layout is correct.