### PR TITLE
Make the default target for expectation files as x86_64-unknown-linux

### DIFF
--- a/tests/headers/call-conv-field.h
+++ b/tests/headers/call-conv-field.h
@@ -1,4 +1,4 @@
-// bindgen-flags: -- -target i686-pc-win32
+// bindgen-flags: -- --target=i686-pc-win32
 // bindgen-unstable
 // bindgen-generate-bindings-on-linux-only
 //

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -235,18 +235,13 @@ fn create_bindgen_builder(header: &PathBuf) -> Result<Option<Builder>, Error> {
         }
     }
 
-    // Windows platform has various different conventions than *nix platforms,
-    // e.g. default enum underlying type, struct padding, mangling. Most tests
-    // were written and checked on Linux and macOS, and thus they could fail on
-    // Windows. We just make those tests targetting Linux instead as far as one
-    // isn't annotated for a specific target.
-    if cfg!(target_os = "windows") {
-        if flags.iter().all(|flag| !flag.starts_with("--target=")) {
-            if !flags.iter().any(|flag| flag == "--") {
-                flags.push("--".into());
-            }
-            flags.push("--target=x86_64-unknown-linux".into());
+    // Different platforms have various different conventions like struct padding, mangling, etc.
+    // We make the default target as x86_64-unknown-linux
+    if flags.iter().all(|flag| !flag.starts_with("--target=")) {
+        if !flags.iter().any(|flag| flag == "--") {
+            flags.push("--".into());
         }
+        flags.push("--target=x86_64-unknown-linux".into());
     }
 
     // Fool builder_from_flags() into believing it has real env::args_os...

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -302,6 +302,7 @@ include!(concat!(env!("OUT_DIR"), "/tests.rs"));
 fn test_header_contents() {
     let actual = builder()
         .header_contents("test.h", "int foo(const char* a);")
+        .clang_arg("--target=x86_64-unknown-linux")
         .generate()
         .unwrap()
         .to_string();
@@ -330,6 +331,7 @@ fn test_multiple_header_calls_in_builder() {
             "/tests/headers/func_ptr.h"
         ))
         .header(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/headers/char.h"))
+        .clang_arg("--target=x86_64-unknown-linux")
         .generate()
         .unwrap()
         .to_string();


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rust-bindgen/issues/1067
I didn't check it on macos because I don't have one, but it will be a surprise if it doesn't work.