### PR TITLE
ir: We can't guarantee the type to be in the item map while propagating AlreadyResolved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.31.2"
+version = "0.31.3"
 build = "build.rs"
 
 include = [

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1512,7 +1512,7 @@ impl ClangItemParser for Item {
         let result = Type::from_clang_ty(id, ty, location, parent_id, ctx);
         let relevant_parent_id = parent_id.unwrap_or(current_module);
         let ret = match result {
-            Ok(ParseResult::AlreadyResolved(ty)) => Ok(ty.expect_type_id(ctx)),
+            Ok(ParseResult::AlreadyResolved(ty)) => Ok(ty.as_type_id_unchecked()),
             Ok(ParseResult::New(item, declaration)) => {
                 ctx.add_item(
                     Item::new(


### PR DESCRIPTION
The item may come from a recursive check down the stack, and as we say there:

> Unchecked because we haven't finished this type yet.

Fixes #1127