### PR TITLE
Actually cleanup temp files in predicate

### DIFF
--- a/csmith-fuzzing/predicate.py
+++ b/csmith-fuzzing/predicate.py
@@ -144,7 +144,7 @@ def main():
         exit_code = 2
         print("Unexpected exception:", e)
 
-    for p in TEMP_FILES:
+    for path in TEMP_FILES:
         try:
             os.remove(path)
         except:

--- a/csmith-fuzzing/predicate.py
+++ b/csmith-fuzzing/predicate.py
@@ -147,8 +147,8 @@ def main():
     for path in TEMP_FILES:
         try:
             os.remove(path)
-        except:
-            pass
+        except Exception as e:
+            print("Unexpected exception:", e)
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
Embarrassingly, we were ignoring and swallowing a dumb reference error that prevented the temp files from ever getting cleaned up.

The good news: with ignoring bitfields and packed structs, I got to `driver.py` iteration 27145 without triggering any `bindgen` bugs, and then the disk got full! :-p

r? @pepyakin 