### PR TITLE
Detect `#pragma pack(...)` and make `pack(n)` where `n > 1` opaque

### DIFF
--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -378,7 +378,7 @@ impl IsOpaque for Type {
             TypeKind::TemplateInstantiation(ref inst) => {
                 inst.is_opaque(ctx, item)
             }
-            TypeKind::Comp(ref comp) => comp.is_opaque(ctx, &()),
+            TypeKind::Comp(ref comp) => comp.is_opaque(ctx, &self.layout),
             TypeKind::ResolvedTypeRef(to) => to.is_opaque(ctx, &()),
             _ => false,
         }

--- a/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -30,11 +30,12 @@ impl WithBitfieldAndAttrPacked {
         0
     }
 }
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfieldAndPacked {
     pub _bitfield_1: [u8; 0usize],
     pub a: ::std::os::raw::c_uint,
+    pub __bindgen_padding_0: u8,
 }
 impl WithBitfieldAndPacked {
     #[inline]

--- a/tests/expectations/tests/layout.rs
+++ b/tests/expectations/tests/layout.rs
@@ -5,49 +5,8 @@
 
 
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>);
-impl<T> __IncompleteArrayField<T> {
-    #[inline]
-    pub fn new() -> Self {
-        __IncompleteArrayField(::std::marker::PhantomData)
-    }
-    #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
-    }
-    #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
-    }
-    #[inline]
-    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
-    }
-    #[inline]
-    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-    }
-}
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        fmt.write_str("__IncompleteArrayField")
-    }
-}
-impl<T> ::std::clone::Clone for __IncompleteArrayField<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self::new()
-    }
-}
-impl<T> ::std::marker::Copy for __IncompleteArrayField<T> {}
-#[repr(C, packed)]
-#[derive(Debug, Default)]
 pub struct header {
-    pub proto: ::std::os::raw::c_char,
-    pub size: ::std::os::raw::c_uint,
-    pub data: __IncompleteArrayField<::std::os::raw::c_uchar>,
-    pub __bindgen_padding_0: [u8; 11usize],
+    pub _bindgen_opaque_blob: [u8; 16usize],
 }
 #[test]
 fn bindgen_test_layout_header() {
@@ -56,4 +15,9 @@ fn bindgen_test_layout_header() {
         16usize,
         concat!("Size of: ", stringify!(header))
     );
+}
+impl Default for header {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }

--- a/tests/headers/issue-537.h
+++ b/tests/headers/issue-537.h
@@ -1,0 +1,35 @@
+/// This should not be opaque; we can see the attributes and can pack the
+/// struct.
+struct AlignedToOne {
+    int i;
+} __attribute__ ((packed,aligned(1)));
+
+/// This should be opaque because although we can see the attributes, Rust
+/// doesn't have `#[repr(packed = "N")]` yet.
+struct AlignedToTwo {
+    int i;
+} __attribute__ ((packed,aligned(2)));
+
+#pragma pack(1)
+
+/// This should not be opaque because although `libclang` doesn't give us the
+/// `#pragma pack(1)`, we can detect that alignment is 1 and add
+/// `#[repr(packed)]` to the struct ourselves.
+struct PackedToOne {
+    int x;
+    int y;
+};
+
+#pragma pack()
+
+#pragma pack(2)
+
+/// In this case, even if we can detect the weird alignment triggered by
+/// `#pragma pack(2)`, we can't do anything about it because Rust doesn't have
+/// `#[repr(packed = "N")]`. Therefore, we must make it opaque.
+struct PackedToTwo {
+    int x;
+    int y;
+};
+
+#pragma pack()


### PR DESCRIPTION
This is a bandaid for #537. It does *not* fix the underlying issue, which requires `#[repr(packed = "N")]` support in Rust. However, it does make sure that we don't generate type definitions with the wrong layout, or fail our generated layout tests.

r? @emilio or @pepyakin 