### PR TITLE
Remove unnecessary flag from rustfmt invocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1721,7 +1721,6 @@ impl Bindings {
         };
 
         cmd
-            .args(&["--write-mode=display"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped());
 


### PR DESCRIPTION
From rustfmt docs, the --write-mode flag is unecessary when passing the flag to stdin. If we leave it there, rustfmt-nightly complains that it cannot find the file named --write-mode, so let's remove the flag.

here's the logs when I leave the flag : 

```
Error: file `--write-mode=display` does not exist
Error { repr: Custom(Custom { kind: Other, error: StringError("Internal rustfmt error") }) }
```

<details>
<summary>The build.rs : </summary>

```rust
extern crate bindgen;

use std::env;
use std::path::PathBuf;

fn main() {
    println!("cargo:rustc-link-lib=static=transistor.nro");
    println!("cargo:rustc-link-search=native=libtransistor/build/lib");

    let bindings = bindgen::Builder::default()
        .header("libtransistor/include/libtransistor/nx.h")
        // Don't use host headers, to make sure we're building against newlib
        .clang_arg("-nostdinc")
        // Include the newlib/transistor headers, and the clang builtin headers
        .clang_args(&["-isystem", "/usr/lib/clang/5.0.0/include"])
        .clang_args(&["-isystem", "libtransistor/newlib/newlib/libc/include"])
        .clang_args(&["-isystem", "libtransistor/newlib/newlib/libc/sys/switch/include"])
        .clang_arg("-Ilibtransistor/include")
        // We don't need to define those types, rust has them already anyways.
        // Blacklisting avoids a bug in bindgen where it creates cyclic references
        // (pub type u8 = u8)
        .blacklist_type("u(8|16|32|64)")
        .rustfmt_bindings(true)
        .rustfmt_configuration_file(None)
        .generate()
        .expect("Unable to generate bindings");

    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
    bindings
        .write_to_file(out_path.join("bindings.rs"))
        .expect("Couldn't write bindings!");
}
```
</details>