### PR TITLE
Avoid bitfield getters and setters accessing memory beyond "self"

### DIFF
--- a/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -30,7 +30,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x1 as u64;
@@ -46,7 +46,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -55,7 +55,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -66,7 +66,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x2 as u64;
@@ -82,7 +82,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -91,7 +91,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -102,7 +102,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x4 as u64;
@@ -118,7 +118,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -127,7 +127,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -138,7 +138,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x8 as u64;
@@ -154,7 +154,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -163,7 +163,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -174,7 +174,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x10 as u64;
@@ -190,7 +190,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -199,7 +199,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -210,7 +210,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x20 as u64;
@@ -226,7 +226,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -235,7 +235,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -246,7 +246,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x40 as u64;
@@ -262,7 +262,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -271,7 +271,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -282,7 +282,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x80 as u64;
@@ -298,7 +298,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -307,7 +307,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -318,7 +318,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x100 as u64;
@@ -334,7 +334,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -343,7 +343,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -354,7 +354,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x200 as u64;
@@ -370,7 +370,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -379,7 +379,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -390,7 +390,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x400 as u64;
@@ -406,7 +406,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -415,7 +415,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -426,7 +426,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x800 as u64;
@@ -442,7 +442,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -451,7 +451,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -462,7 +462,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x1000 as u64;
@@ -478,7 +478,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -487,7 +487,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -498,7 +498,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x2000 as u64;
@@ -514,7 +514,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -523,7 +523,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -534,7 +534,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x4000 as u64;
@@ -550,7 +550,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -559,7 +559,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -570,7 +570,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x8000 as u64;
@@ -586,7 +586,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -595,7 +595,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -606,7 +606,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x10000 as u64;
@@ -622,7 +622,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -631,7 +631,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -642,7 +642,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x20000 as u64;
@@ -658,7 +658,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -667,7 +667,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -678,7 +678,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x40000 as u64;
@@ -694,7 +694,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -703,7 +703,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -714,7 +714,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x80000 as u64;
@@ -730,7 +730,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -739,7 +739,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -750,7 +750,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x100000 as u64;
@@ -766,7 +766,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -775,7 +775,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -786,7 +786,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x200000 as u64;
@@ -802,7 +802,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -811,7 +811,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -822,7 +822,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x400000 as u64;
@@ -838,7 +838,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -847,7 +847,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -858,7 +858,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x800000 as u64;
@@ -874,7 +874,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -883,7 +883,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -894,7 +894,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x1000000 as u64;
@@ -910,7 +910,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -919,7 +919,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -930,7 +930,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x2000000 as u64;
@@ -946,7 +946,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -955,7 +955,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -966,7 +966,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x4000000 as u64;
@@ -982,7 +982,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -991,7 +991,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1002,7 +1002,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x8000000 as u64;
@@ -1018,7 +1018,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1027,7 +1027,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1038,7 +1038,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x10000000 as u64;
@@ -1054,7 +1054,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1063,7 +1063,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1074,7 +1074,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x20000000 as u64;
@@ -1090,7 +1090,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1099,7 +1099,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1110,7 +1110,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x40000000 as u64;
@@ -1126,7 +1126,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1135,7 +1135,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1146,7 +1146,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x80000000 as u64;
@@ -1162,7 +1162,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1171,7 +1171,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }
@@ -1182,7 +1182,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         let mask = 0x100000000 as u64;
@@ -1198,7 +1198,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             )
         };
         unit_field_val &= !mask;
@@ -1207,7 +1207,7 @@ impl MuchBitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                5usize,
             );
         }
     }

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -42,7 +42,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x7 as u8;
@@ -58,7 +58,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -67,7 +67,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -43,7 +43,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x1 as u16;
@@ -59,7 +59,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -68,7 +68,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -79,7 +79,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x2 as u16;
@@ -95,7 +95,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -104,7 +104,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -115,7 +115,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x4 as u16;
@@ -131,7 +131,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -140,7 +140,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -151,7 +151,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x8 as u16;
@@ -167,7 +167,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -176,7 +176,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -187,7 +187,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x10 as u16;
@@ -203,7 +203,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -212,7 +212,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -223,7 +223,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x20 as u16;
@@ -239,7 +239,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -248,7 +248,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -259,7 +259,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x40 as u16;
@@ -275,7 +275,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -284,7 +284,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -295,7 +295,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x80 as u16;
@@ -311,7 +311,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -320,7 +320,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -331,7 +331,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x100 as u16;
@@ -347,7 +347,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -356,7 +356,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -367,7 +367,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x200 as u16;
@@ -383,7 +383,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -392,7 +392,7 @@ impl A {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -448,7 +448,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7fffffff as u32;
@@ -464,7 +464,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -473,7 +473,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -484,7 +484,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x80000000 as u32;
@@ -500,7 +500,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -509,7 +509,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -557,7 +557,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -573,7 +573,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -582,7 +582,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -593,7 +593,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x2 as u8;
@@ -609,7 +609,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -618,7 +618,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -656,7 +656,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x7 as u32;
@@ -672,7 +672,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -681,7 +681,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -692,7 +692,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x1f8 as u32;
@@ -708,7 +708,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -717,7 +717,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -728,7 +728,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x3e00 as u32;
@@ -744,7 +744,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -753,7 +753,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -764,7 +764,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0xff0000 as u32;
@@ -780,7 +780,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -789,7 +789,7 @@ impl Date1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -833,7 +833,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7 as u32;
@@ -849,7 +849,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -858,7 +858,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -869,7 +869,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x1f8 as u32;
@@ -885,7 +885,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -894,7 +894,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -905,7 +905,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x3e00 as u32;
@@ -921,7 +921,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -930,7 +930,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -941,7 +941,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xff0000 as u32;
@@ -957,7 +957,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -966,7 +966,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -977,7 +977,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xff000000 as u32;
@@ -993,7 +993,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -1002,7 +1002,7 @@ impl Date2 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -1059,7 +1059,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x7 as u32;
@@ -1075,7 +1075,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -1084,7 +1084,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -1095,7 +1095,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x1f8 as u32;
@@ -1111,7 +1111,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -1120,7 +1120,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -1131,7 +1131,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0x3e00 as u32;
@@ -1147,7 +1147,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -1156,7 +1156,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }
@@ -1167,7 +1167,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         let mask = 0xff0000 as u32;
@@ -1183,7 +1183,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             )
         };
         unit_field_val &= !mask;
@@ -1192,7 +1192,7 @@ impl Date3 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                3usize,
             );
         }
     }

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -44,7 +44,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x3 as u64;
@@ -60,7 +60,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -69,7 +69,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -80,7 +80,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xfffffffffffffffc as u64;
@@ -96,7 +96,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -105,7 +105,7 @@ impl TaggedPtr {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -31,7 +31,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xffffff as u32;
@@ -47,7 +47,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -56,7 +56,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -67,7 +67,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xff000000 as u32;
@@ -83,7 +83,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -92,7 +92,7 @@ impl mach_msg_type_descriptor_t {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -83,7 +83,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x7 as u16;
@@ -99,7 +99,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -108,7 +108,7 @@ impl Foo {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -61,7 +61,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -77,7 +77,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -86,7 +86,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -97,7 +97,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0xfe as u8;
@@ -113,7 +113,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -122,7 +122,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -52,7 +52,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -68,7 +68,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -77,7 +77,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -88,7 +88,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0xfe as u8;
@@ -104,7 +104,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -113,7 +113,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -115,7 +115,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x7fffffffffff as u64;
@@ -131,7 +131,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -140,7 +140,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -151,7 +151,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xffff800000000000 as u64;
@@ -167,7 +167,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -176,7 +176,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -163,7 +163,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x7fffffffffff as u64;
@@ -179,7 +179,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -188,7 +188,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -199,7 +199,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xffff800000000000 as u64;
@@ -215,7 +215,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -224,7 +224,7 @@ impl jsval_layout__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -114,7 +114,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -130,7 +130,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -139,7 +139,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -150,7 +150,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x2 as u8;
@@ -166,7 +166,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -175,7 +175,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -186,7 +186,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x4 as u8;
@@ -202,7 +202,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -211,7 +211,7 @@ impl rte_eth_link {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -118,7 +118,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x1 as u16;
@@ -134,7 +134,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -143,7 +143,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -154,7 +154,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x2 as u16;
@@ -170,7 +170,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -179,7 +179,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -190,7 +190,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x4 as u16;
@@ -206,7 +206,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -215,7 +215,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -226,7 +226,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x8 as u16;
@@ -242,7 +242,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -251,7 +251,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -262,7 +262,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x10 as u16;
@@ -278,7 +278,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -287,7 +287,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -298,7 +298,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x20 as u16;
@@ -314,7 +314,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -323,7 +323,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -334,7 +334,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x40 as u16;
@@ -350,7 +350,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -359,7 +359,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -370,7 +370,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x80 as u16;
@@ -386,7 +386,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -395,7 +395,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -406,7 +406,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x100 as u16;
@@ -422,7 +422,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -431,7 +431,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -524,7 +524,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -540,7 +540,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -549,7 +549,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -560,7 +560,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x2 as u8;
@@ -576,7 +576,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -585,7 +585,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -596,7 +596,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x4 as u8;
@@ -612,7 +612,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -621,7 +621,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -166,7 +166,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x1 as u16;
@@ -182,7 +182,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -191,7 +191,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -202,7 +202,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x2 as u16;
@@ -218,7 +218,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -227,7 +227,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -238,7 +238,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x4 as u16;
@@ -254,7 +254,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -263,7 +263,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -274,7 +274,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x8 as u16;
@@ -290,7 +290,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -299,7 +299,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -310,7 +310,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x10 as u16;
@@ -326,7 +326,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -335,7 +335,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -346,7 +346,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x20 as u16;
@@ -362,7 +362,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -371,7 +371,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -382,7 +382,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x40 as u16;
@@ -398,7 +398,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -407,7 +407,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -418,7 +418,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x80 as u16;
@@ -434,7 +434,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -443,7 +443,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -454,7 +454,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x100 as u16;
@@ -470,7 +470,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -479,7 +479,7 @@ impl rte_eth_rxmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -577,7 +577,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -593,7 +593,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -602,7 +602,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -613,7 +613,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x2 as u8;
@@ -629,7 +629,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -638,7 +638,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -649,7 +649,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x4 as u8;
@@ -665,7 +665,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -674,7 +674,7 @@ impl rte_eth_txmode {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -181,7 +181,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf as u32;
@@ -197,7 +197,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -206,7 +206,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -217,7 +217,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf0 as u32;
@@ -233,7 +233,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -242,7 +242,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -253,7 +253,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf00 as u32;
@@ -269,7 +269,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -278,7 +278,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -289,7 +289,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf000 as u32;
@@ -305,7 +305,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -314,7 +314,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -325,7 +325,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf0000 as u32;
@@ -341,7 +341,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -350,7 +350,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -361,7 +361,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf00000 as u32;
@@ -377,7 +377,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -386,7 +386,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -397,7 +397,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf000000 as u32;
@@ -413,7 +413,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -422,7 +422,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -812,7 +812,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x7f as u64;
@@ -828,7 +828,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -837,7 +837,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -848,7 +848,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xff80 as u64;
@@ -864,7 +864,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -873,7 +873,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -884,7 +884,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xff0000 as u64;
@@ -900,7 +900,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -909,7 +909,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -920,7 +920,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xffff000000 as u64;
@@ -936,7 +936,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -945,7 +945,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -956,7 +956,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x1ff0000000000 as u64;
@@ -972,7 +972,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -981,7 +981,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -992,7 +992,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xfe000000000000 as u64;
@@ -1008,7 +1008,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -1017,7 +1017,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -234,7 +234,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf as u32;
@@ -250,7 +250,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -259,7 +259,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -270,7 +270,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf0 as u32;
@@ -286,7 +286,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -295,7 +295,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -306,7 +306,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf00 as u32;
@@ -322,7 +322,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -331,7 +331,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -342,7 +342,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf000 as u32;
@@ -358,7 +358,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -367,7 +367,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -378,7 +378,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf0000 as u32;
@@ -394,7 +394,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -403,7 +403,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -414,7 +414,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf00000 as u32;
@@ -430,7 +430,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -439,7 +439,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -450,7 +450,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xf000000 as u32;
@@ -466,7 +466,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -475,7 +475,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -881,7 +881,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x7f as u64;
@@ -897,7 +897,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -906,7 +906,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -917,7 +917,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xff80 as u64;
@@ -933,7 +933,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -942,7 +942,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -953,7 +953,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xff0000 as u64;
@@ -969,7 +969,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -978,7 +978,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -989,7 +989,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xffff000000 as u64;
@@ -1005,7 +1005,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -1014,7 +1014,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -1025,7 +1025,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x1ff0000000000 as u64;
@@ -1041,7 +1041,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -1050,7 +1050,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -1061,7 +1061,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xfe000000000000 as u64;
@@ -1077,7 +1077,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -1086,7 +1086,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -30,7 +30,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -46,7 +46,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -55,7 +55,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -66,7 +66,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0xfe as u8;
@@ -82,7 +82,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -91,7 +91,7 @@ impl C {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -42,7 +42,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -58,7 +58,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -67,7 +67,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -78,7 +78,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x2 as u8;
@@ -94,7 +94,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -103,7 +103,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -114,7 +114,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x4 as u8;
@@ -130,7 +130,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -139,7 +139,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -150,7 +150,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0xc0 as u8;
@@ -166,7 +166,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -175,7 +175,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -198,7 +198,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0x3 as u64;
@@ -214,7 +214,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -223,7 +223,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }
@@ -234,7 +234,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         let mask = 0xffffffff00000000 as u64;
@@ -250,7 +250,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u64 as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             )
         };
         unit_field_val &= !mask;
@@ -259,7 +259,7 @@ impl bitfield {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u64>(),
+                8usize,
             );
         }
     }

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -36,7 +36,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -52,7 +52,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -61,7 +61,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -102,7 +102,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7fffffff as u32;
@@ -118,7 +118,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -127,7 +127,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -138,7 +138,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x80000000 as u32;
@@ -154,7 +154,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -163,7 +163,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -79,7 +79,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         let mask = 0x1 as u8;
@@ -95,7 +95,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u8 as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             )
         };
         unit_field_val &= !mask;
@@ -104,7 +104,7 @@ impl U4 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u8>(),
+                1usize,
             );
         }
     }
@@ -145,7 +145,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7fffffff as u32;
@@ -161,7 +161,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -170,7 +170,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -181,7 +181,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x80000000 as u32;
@@ -197,7 +197,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -206,7 +206,7 @@ impl B {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -38,7 +38,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7f as u32;
@@ -54,7 +54,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -63,7 +63,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -74,7 +74,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xffffff80 as u32;
@@ -90,7 +90,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -99,7 +99,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -86,7 +86,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7f as u32;
@@ -102,7 +102,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -111,7 +111,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -122,7 +122,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xffffff80 as u32;
@@ -138,7 +138,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -147,7 +147,7 @@ impl foo__bindgen_ty_1 {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -176,7 +176,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0xffff as u32;
@@ -192,7 +192,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -201,7 +201,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -212,7 +212,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         let mask = 0x7fff0000 as u32;
@@ -228,7 +228,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_1 as *const _ as *const u8,
                 &mut unit_field_val as *mut u32 as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             )
         };
         unit_field_val &= !mask;
@@ -237,7 +237,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_1 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u32>(),
+                4usize,
             );
         }
     }
@@ -256,7 +256,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x7 as u16;
@@ -272,7 +272,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -281,7 +281,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -292,7 +292,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x38 as u16;
@@ -308,7 +308,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -317,7 +317,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -328,7 +328,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x40 as u16;
@@ -344,7 +344,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -353,7 +353,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -364,7 +364,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x80 as u16;
@@ -380,7 +380,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -389,7 +389,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }
@@ -400,7 +400,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         let mask = 0x100 as u16;
@@ -416,7 +416,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &self._bitfield_2 as *const _ as *const u8,
                 &mut unit_field_val as *mut u16 as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             )
         };
         unit_field_val &= !mask;
@@ -425,7 +425,7 @@ impl Weird {
             ::std::ptr::copy_nonoverlapping(
                 &unit_field_val as *const _ as *const u8,
                 &mut self._bitfield_2 as *mut _ as *mut u8,
-                ::std::mem::size_of::<u16>(),
+                2usize,
             );
         }
     }


### PR DESCRIPTION
This fixes https://github.com/rust-lang-nursery/rust-bindgen/issues/954.

r? @emilio