### PR TITLE
Properly handle namespaces for enum configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,13 @@ Released YYYY/MM/DD
 
 ## Changed
 
-* TODO (or remove section if none)
+* The `bindgen::Builder::{constified_enum_module,{bitfield,rustified}_enum}`
+  builder methods and their corresponding CLI flags now compare their argument
+  to the C/C++ `enum`'s "canonical path", which includes leading namespaces,
+  rather than its "canonical name", which does not. This is a breaking change
+  that requires callers which target a namespaced C++ enum to call e.g.
+  `bitfield_enum("<namespace>::<enum_name>")` rather than e.g.
+  `bitfield_enum("<enum_name>")`. [#1162][]
 
 ## Deprecated
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2419,8 +2419,6 @@ impl CodeGenerator for Enum {
             }
         };
 
-        // FIXME(emilio): These should probably use the path so it can
-        // disambiguate between namespaces, just like is_opaque etc.
         let variation = if self.is_bitfield(ctx, item) {
             EnumVariation::Bitfield
         } else if self.is_rustified_enum(ctx, item) {

--- a/src/ir/enum_ty.rs
+++ b/src/ir/enum_ty.rs
@@ -5,7 +5,7 @@ use super::item::Item;
 use super::ty::TypeKind;
 use clang;
 use ir::annotations::Annotations;
-use ir::item::ItemCanonicalName;
+use ir::item::ItemCanonicalPath;
 use parse::{ClangItemParser, ParseError};
 
 /// An enum representing custom handling that can be given to a variant.
@@ -130,10 +130,10 @@ impl Enum {
 
     /// Whether the enum should be a bitfield
     pub fn is_bitfield(&self, ctx: &BindgenContext, item: &Item) -> bool {
-        let name = item.canonical_name(ctx);
+        let path = item.canonical_path(ctx);
         let enum_ty = item.expect_type();
 
-        ctx.options().bitfield_enums.matches(&name) ||
+        ctx.options().bitfield_enums.matches(&path[1..].join("::")) ||
             (enum_ty.name().is_none() &&
                     self.variants().iter().any(|v| {
                     ctx.options().bitfield_enums.matches(&v.name())
@@ -146,10 +146,10 @@ impl Enum {
         ctx: &BindgenContext,
         item: &Item,
     ) -> bool {
-        let name = item.canonical_name(ctx);
+        let path = item.canonical_path(ctx);
         let enum_ty = item.expect_type();
 
-        ctx.options().constified_enum_modules.matches(&name) ||
+        ctx.options().constified_enum_modules.matches(&path[1..].join("::")) ||
             (enum_ty.name().is_none() &&
                  self.variants().iter().any(|v| {
                     ctx.options().constified_enum_modules.matches(&v.name())
@@ -158,10 +158,10 @@ impl Enum {
 
     /// Whether the enum should be a Rust enum
     pub fn is_rustified_enum(&self, ctx: &BindgenContext, item: &Item) -> bool {
-        let name = item.canonical_name(ctx);
+        let path = item.canonical_path(ctx);
         let enum_ty = item.expect_type();
 
-        ctx.options().rustified_enums.matches(&name) ||
+        ctx.options().rustified_enums.matches(&path[1..].join("::")) ||
             (enum_ty.name().is_none() &&
                 self.variants().iter().any(|v| {
                     ctx.options().rustified_enums.matches(&v.name())

--- a/tests/headers/constify-module-enums-namespace.hpp
+++ b/tests/headers/constify-module-enums-namespace.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --enable-cxx-namespaces --constified-enum-module foo
+// bindgen-flags: --enable-cxx-namespaces --constified-enum-module ns1::ns2::foo
 
 namespace ns1 {
   namespace ns2 {

--- a/tests/headers/constify-module-enums-simple-nonamespace.hpp
+++ b/tests/headers/constify-module-enums-simple-nonamespace.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --constified-enum-module one_Foo
+// bindgen-flags: --constified-enum-module one::Foo
 
 namespace one {
   enum class Foo {


### PR DESCRIPTION
...by using canonical_path rather than canonical_name.

Fixes #1125.

r? @emilio 