### PR TITLE
Enable Cargo features for quickchecking crate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ See [./csmith-fuzzing/README.md](./csmith-fuzzing/README.md) for details.
 
 ### Property tests for `bindgen` with `quickchecking`
 
-The `tests/quickchecking` crate genertates property tests for `bindgen`.
+The `tests/quickchecking` crate generates property tests for `bindgen`.
 From the crate's directory you can run the tests with `cargo run`. For details
 on additional configuration including how to preserve / inspect the generated 
 property tests, see 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ out to us in a GitHub issue, or stop by
   - [Test Expectations and `libclang` Versions](#test-expectations-and-libclang-versions)
   - [Integration Tests](#integration-tests)
   - [Fuzzing `bindgen` with `csmith`](#fuzzing-bindgen-with-csmith)
+  - [Property tests for `bindgen` with `quickchecking`](#property-tests-for-bindgen-with-quickchecking)
 - [Code Overview](#code-overview)
 - [Pull Requests and Code Reviews](#pull-requests-and-code-reviews)
 - [Generating Graphviz Dot Files](#generating-graphviz-dot-files)
@@ -223,6 +224,14 @@ uncover hidden bugs is by running `csmith` to generate random headers to test
 `bindgen` against.
 
 See [./csmith-fuzzing/README.md](./csmith-fuzzing/README.md) for details.
+
+### Property tests for `bindgen` with `quickchecking`
+
+The `tests/quickchecking` crate genertates property tests for `bindgen`.
+From the crate's directory you can run the tests with `cargo run`. For details
+on additional configuration including how to preserve / inspect the generated 
+property tests, see 
+[./tests/quickchecking/README.md](./tests/quickchecking/README.md).
 
 ## Code Overview
 

--- a/tests/quickchecking/Cargo.toml
+++ b/tests/quickchecking/Cargo.toml
@@ -18,3 +18,15 @@ lazy_static = "1.0"
 quickcheck = "0.4"
 rand = "0.3"
 tempdir = "0.3"
+
+[features]
+# No features by default.
+default = []
+
+# Enable the generation of code that allows for zero sized arrays as struct
+# fields. Until issues #684 and #1153 are resolved this can result in failing tests. 
+zero-sized-arrays = [] 
+
+# Enable the generation of code that allows for long double types as struct
+# fields. Until issue #550 is resolved this can result in failing tests.
+long-doubles = []

--- a/tests/quickchecking/README.md
+++ b/tests/quickchecking/README.md
@@ -35,25 +35,5 @@ Run `quickchecking` binary to generate and test fuzzed C headers with
 
 ```
 $ cargo run --bin=quickchecking -- -h
-quickchecking 0.2.0
-Bindgen property tests with quickcheck. Generate random valid C code and pass it to the csmith/predicate.py script
-
-USAGE:
-    quickchecking [OPTIONS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -c, --count <COUNT>    Count / number of tests to run. Running a fuzzed header through the predicate.py script can
-                           take a long time, especially if the generation range is large. Increase this number if you're
-                           willing to wait a while. [default: 2]
-    -p, --path <PATH>      Optional. Preserve generated headers for inspection, provide directory path for header
-                           output. [default: None] 
-    -r, --range <RANGE>    Sets the range quickcheck uses during generation. Corresponds to things like arbitrary usize
-                           and arbitrary vector length. This number doesn't have to grow much for execution time to
-                           increase significantly. [default: 32]
-
 ```
 [quickcheck]: https://github.com/BurntSushi/quickcheck

--- a/tests/quickchecking/README.md
+++ b/tests/quickchecking/README.md
@@ -1,0 +1,59 @@
+# Property tests for `bindgen` with `quickchecking`
+
+`quickchecking` generates random C headers to test `bindgen` 
+using the [`quickcheck`][quickcheck] property testing crate. When testing 
+`bindgen` with `quickchecking`, the generated header files are passed to 
+`bindgen`'s `csmith-fuzzing/predicate.py` script. If that script fails, 
+`quickchecking` panics, and you can report an issue containing the test case!
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Prerequisites](#prerequisites)
+- [Running](#running)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Prerequisites
+
+Requires `python3` to be in `$PATH`.
+
+Many systems have `python3` by default but if your OS doesn't, its package 
+manager may make it available:
+
+```
+$ sudo apt install python3
+$ brew install python3
+$ # Etc...
+```
+
+## Running
+
+Run `quickchecking` binary to generate and test fuzzed C headers with 
+`cargo run`. Additional configuration is exposed through the binary's CLI.
+
+```
+$ cargo run --bin=quickchecking -- -h
+quickchecking 0.2.0
+Bindgen property tests with quickcheck. Generate random valid C code and pass it to the csmith/predicate.py script
+
+USAGE:
+    quickchecking [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --count <COUNT>    Count / number of tests to run. Running a fuzzed header through the predicate.py script can
+                           take a long time, especially if the generation range is large. Increase this number if you're
+                           willing to wait a while. [default: 2]
+    -p, --path <PATH>      Optional. Preserve generated headers for inspection, provide directory path for header
+                           output. [default: None] 
+    -r, --range <RANGE>    Sets the range quickcheck uses during generation. Corresponds to things like arbitrary usize
+                           and arbitrary vector length. This number doesn't have to grow much for execution time to
+                           increase significantly. [default: 32]
+
+```
+[quickcheck]: https://github.com/BurntSushi/quickcheck

--- a/tests/quickchecking/src/bin.rs
+++ b/tests/quickchecking/src/bin.rs
@@ -1,5 +1,5 @@
-//! An application to run property tests for `bindgen` with _fuzzed_ C headers 
-//! using `quickcheck` 
+//! An application to run property tests for `bindgen` with _fuzzed_ C headers
+//! using `quickcheck`
 //!
 //! ## Usage
 //!
@@ -77,7 +77,7 @@ fn main() {
                     "Sets the range quickcheck uses during generation. \
                      Corresponds to things like arbitrary usize and \
                      arbitrary vector length. This number doesn't have \
-                     to grow much for that execution time to increase \
+                     to grow much for execution time to increase \
                      significantly.",
                 )
                 .takes_value(true)


### PR DESCRIPTION
Logic to enable/disable special casing (due to known issues #550, #684, and #1153) has been exposed as features in the `quickchecking` crate's Cargo.toml file and corresponding `cfg` attributes in the source.

In addition to adding Cargo features, this PR represents the following:
- Documentation in `bindgen`'s CONTRIBUTING.md that points to a new README.md located in the `quickchecking` crate's directory.
- The Debug trait was implemented for the `HeaderC` type. This enables failing property tests to be reported as C source code rather than a Rust data structure.
- The ArrayDimensionC type is now used in header generation for union, struct, and basic declarations.

Thanks for taking a look and for any feedback!

Closes #1169

r? @fitzgen