### PR TITLE
Revert to only calling plain rustfmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1711,15 +1711,7 @@ impl Bindings {
         let rustfmt = which::which("rustfmt")
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_owned()))?;
 
-        // Prefer using the `rustfmt-nightly` version of `rustmft`, if
-        // possible. It requires being run via `rustup run nightly ...`.
-        let mut cmd = if let Ok(rustup) = which::which("rustup") {
-            let mut cmd = Command::new(rustup);
-            cmd.args(&["run", "nightly", "rustfmt", "--"]);
-            cmd
-        } else {
-            Command::new(rustfmt)
-        };
+        let mut cmd = Command::new(rustfmt);
 
         cmd
             .stdin(Stdio::piped())


### PR DESCRIPTION
rust-lang-nursery/rustup.rs#1294 added a proxy executable for rustfmt that will act on the correct bundled rustfmt for the default release channel set by rustup.

And, assuming I'm reading the expected release notes correctly, it seems like rust 1.23, due out fairly shortly, will add the bundled version of rustfmt to stable.

This fixes #1184 