### PR TITLE
Make CARGO_PKG_VERSION option_env!, rather than env!

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -19,7 +19,7 @@ where
     );
 
     let matches = App::new("bindgen")
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"))
         .about("Generates Rust bindings from C/C++ headers.")
         .usage("bindgen [FLAGS] [OPTIONS] <header> -- <clang-args>...")
         .args(&[


### PR DESCRIPTION
This PR makes the "CARGO_PKG_VERSION" env variable optional, which facilitates crate compilation using tools other than Cargo.