### PR TITLE
ir: Handle _Complex _Float128 correctly.

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1970,7 +1970,13 @@ impl BindgenContext {
                     CXType_Float => FloatKind::Float,
                     CXType_Double => FloatKind::Double,
                     CXType_LongDouble => FloatKind::LongDouble,
-                    _ => panic!("Non floating-type complex?"),
+                    _ => {
+                        panic!(
+                            "Non floating-type complex? {:?}, {:?}",
+                            ty,
+                            float_type,
+                        )
+                    },
                 };
                 TypeKind::Complex(float_kind)
             }

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1970,6 +1970,7 @@ impl BindgenContext {
                     CXType_Float => FloatKind::Float,
                     CXType_Double => FloatKind::Double,
                     CXType_LongDouble => FloatKind::LongDouble,
+                    CXType_Float128 => FloatKind::Float128,
                     _ => {
                         panic!(
                             "Non floating-type complex? {:?}, {:?}",


### PR DESCRIPTION
Unfortunately we can't test it for the same alignment issues that "long double"
has.

I also included the diagnostic code, just in case it happens again.