### PR TITLE
Support str as input to Builder::no_* functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1191,22 +1191,22 @@ impl Builder {
 
     /// Don't derive `PartialEq` for a given type. Regular
     /// expressions are supported.
-    pub fn no_partialeq(mut self, arg: String) -> Builder {
-        self.options.no_partialeq_types.insert(arg);
+    pub fn no_partialeq<T: Into<String>>(mut self, arg: T) -> Builder {
+        self.options.no_partialeq_types.insert(arg.into());
         self
     }
 
     /// Don't derive `Copy` for a given type. Regular
     /// expressions are supported.
-    pub fn no_copy(mut self, arg: String) -> Self {
-        self.options.no_copy_types.insert(arg);
+    pub fn no_copy<T: Into<String>>(mut self, arg: T) -> Self {
+        self.options.no_copy_types.insert(arg.into());
         self
     }
 
     /// Don't derive `Hash` for a given type. Regular
     /// expressions are supported.
-    pub fn no_hash(mut self, arg: String) -> Builder {
-        self.options.no_hash_types.insert(arg);
+    pub fn no_hash<T: Into<String>>(mut self, arg: T) -> Builder {
+        self.options.no_hash_types.insert(arg.into());
         self
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -589,19 +589,19 @@ where
 
     if let Some(no_partialeq) = matches.values_of("no-partialeq") {
         for regex in no_partialeq {
-            builder = builder.no_partialeq(String::from(regex));
+            builder = builder.no_partialeq(regex);
         }
     }
 
     if let Some(no_copy) = matches.values_of("no-copy") {
         for regex in no_copy {
-            builder = builder.no_copy(String::from(regex));
+            builder = builder.no_copy(regex);
         }
     }
 
     if let Some(no_hash) = matches.values_of("no-hash") {
         for regex in no_hash {
-            builder = builder.no_hash(String::from(regex));
+            builder = builder.no_hash(regex);
         }
     }
 


### PR DESCRIPTION
Previously, only String was supported on these while other functions in Builder worked with both str and String

This tripped me up because `Builder::constified_enum_module` and `Builder::raw_line` worked with string slices but I got a compile error when I tried to use `Builder:;no_copy` 