### PR TITLE
callbacks: Introduce MacroParsingBehavior to allow ignoring macros.

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use bindgen::Builder;
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::callbacks::{MacroParsingBehavior, ParseCallbacks};
 
 #[derive(Debug)]
 struct MacroCallback {
@@ -14,8 +14,14 @@ struct MacroCallback {
 }
 
 impl ParseCallbacks for MacroCallback {
-    fn parsed_macro(&self, _name: &str) {
-        self.macros.write().unwrap().insert(String::from(_name));
+    fn will_parse_macro(&self, name: &str) -> MacroParsingBehavior {
+        self.macros.write().unwrap().insert(name.into());
+
+        if name == "MY_ANNOYING_MACRO" {
+            return MacroParsingBehavior::Ignore
+        }
+
+        MacroParsingBehavior::Default
     }
 }
 

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -2,6 +2,12 @@
 
 #define TESTMACRO
 
+enum {
+  MY_ANNOYING_MACRO =
+#define MY_ANNOYING_MACRO 1
+    MY_ANNOYING_MACRO,
+};
+
 class Test {
   int m_int;
   double m_double;

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -5,11 +5,29 @@ pub use ir::int::IntKind;
 use std::fmt;
 use std::panic::UnwindSafe;
 
+/// An enum to allow ignoring parsing of macros.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MacroParsingBehavior {
+    /// Ignore the macro, generating no code for it, or anything that depends on
+    /// it.
+    Ignore,
+    /// The default behavior bindgen would have otherwise.
+    Default,
+}
+
+impl Default for MacroParsingBehavior {
+    fn default() -> Self {
+        MacroParsingBehavior::Default
+    }
+}
+
 /// A trait to allow configuring different kinds of types in different
 /// situations.
 pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
-    /// This function will be run on every macro that is identified
-    fn parsed_macro(&self, _name: &str) {}
+    /// This function will be run on every macro that is identified.
+    fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
+        MacroParsingBehavior::Default
+    }
 
     /// The integer kind an integer macro should have, given a name and the
     /// value of that macro, or `None` if you want the default to be chosen.


### PR DESCRIPTION
This is symmetric, yet less powerful, than enum_variant_behavior.

Fixes #687.