### PR TITLE
Check for more common C++ header file extensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1111,6 +1111,12 @@ impl Builder {
     /// issues. The resulting file will be named something like `__bindgen.i` or
     /// `__bindgen.ii`
     pub fn dump_preprocessed_input(&self) -> io::Result<()> {
+        fn check_is_cpp(name_file: &str) -> bool {
+            name_file.ends_with(".hpp") || name_file.ends_with(".hxx")
+                || name_file.ends_with(".hh")
+                || name_file.ends_with(".h++")
+        }
+        
         let clang = clang_sys::support::Clang::find(None, &[]).ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "Cannot find clang executable")
         })?;
@@ -1120,11 +1126,13 @@ impl Builder {
         let mut wrapper_contents = String::new();
 
         // Whether we are working with C or C++ inputs.
-        let mut is_cpp = false;
+        let mut is_cpp = self.options.clang_args.windows(2).any(|w| {
+            w[0] == "-x=c++" || w[1] == "-x=c++" || w == &["-x", "c++"]
+        });
 
         // For each input header, add `#include "$header"`.
         for header in &self.input_headers {
-            is_cpp |= header.ends_with(".hpp");
+            is_cpp |= check_is_cpp(header);
 
             wrapper_contents.push_str("#include \"");
             wrapper_contents.push_str(header);
@@ -1134,17 +1142,13 @@ impl Builder {
         // For each input header content, add a prefix line of `#line 0 "$name"`
         // followed by the contents.
         for &(ref name, ref contents) in &self.input_header_contents {
-            is_cpp |= name.ends_with(".hpp");
+            is_cpp |= check_is_cpp(name);
 
             wrapper_contents.push_str("#line 0 \"");
             wrapper_contents.push_str(name);
             wrapper_contents.push_str("\"\n");
             wrapper_contents.push_str(contents);
         }
-
-        is_cpp |= self.options.clang_args.windows(2).any(|w| {
-            w[0] == "-x=c++" || w[1] == "-x=c++" || w == &["-x", "c++"]
-        });
 
         let wrapper_path = PathBuf::from(if is_cpp {
             "__bindgen.cpp"


### PR DESCRIPTION
Also, perform `clang` parameter check earlier. If that results in `is_cpp == true`, the later `|=` operations could be elided.