### PR TITLE
Make some docs more visible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
+homepage = "https://rust-lang-nursery.github.io/rust-bindgen/"
 version = "0.36.0"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ version = "0.36.0"
 build = "build.rs"
 
 include = [
+  "LICENSE",
+  "README.md",
   "Cargo.toml",
   "build.rs",
   "src/*.rs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //! functions and use types defined in the header.
 //!
 //! See the [`Builder`](./struct.Builder.html) struct for usage.
+//!
+//! See the [Users Guide](https://rust-lang-nursery.github.io/rust-bindgen/) for
+//! additional documentation.
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![deny(unused_extern_crates)]


### PR DESCRIPTION
- Link to the user's guide from the docs and manifest
- Include README.md in Cargo package so it is visible on crates.io and docs.rs.
- Include LICENSE in Cargo package so that the package is legal to distribute.