### PR TITLE
 codegen: Allow unused_mut to prevent warnings on little-endian machines.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.37.3"
+version = "0.37.4"
 dependencies = [
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang-nursery/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang-nursery.github.io/rust-bindgen/"
-version = "0.37.3"
+version = "0.37.4"
 build = "build.rs"
 
 include = [

--- a/src/codegen/bitfield_unit.rs
+++ b/src/codegen/bitfield_unit.rs
@@ -27,12 +27,13 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index =
+            if cfg!(target_endian = "big") {
+                7 - (index % 8)
+            } else {
+                index % 8
+            };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -45,14 +46,14 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index =
+            if cfg!(target_endian = "big") {
+                7 - (index % 8)
+            } else {
+                index % 8
+            };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -70,12 +71,12 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index  = i;
-                #[cfg(target_endian = "big")]
-                {
-                   // Adjust the index for endianness.
-                   index  = bit_width as usize - 1 - index;
-                }
+                let index =
+                    if cfg!(target_endian = "big") {
+                        bit_width as usize - 1 - i
+                    } else {
+                        i
+                    };
                 val |= 1 << index;
             }
         }
@@ -92,12 +93,12 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index  = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index  = bit_width as usize - 1 - index;
-            }
+            let index =
+                if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield-large.rs
+++ b/tests/expectations/tests/bitfield-large.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/issue-1034.rs
+++ b/tests/expectations/tests/issue-1034.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/issue-816.rs
+++ b/tests/expectations/tests/issue-816.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -28,12 +28,12 @@ where
         let byte_index = index / 8;
         let byte = self.storage.as_ref()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+
         let mask = 1 << bit_index;
 
         byte & mask == mask
@@ -46,14 +46,13 @@ where
         let byte_index = index / 8;
         let byte = &mut self.storage.as_mut()[byte_index];
 
-        let mut bit_index = index % 8;
-        #[cfg(target_endian = "big")]
-        {
-            // Adjust the index for endianness.
-            bit_index = 7 - bit_index;
-        }
-        let mask = 1 << bit_index;
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
 
+        let mask = 1 << bit_index;
         if val {
             *byte |= mask;
         } else {
@@ -71,12 +70,11 @@ where
 
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
-                let mut index = i;
-                #[cfg(target_endian = "big")]
-                {
-                    // Adjust the index for endianness.
-                    index = bit_width as usize - 1 - index;
-                }
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
                 val |= 1 << index;
             }
         }
@@ -93,12 +91,11 @@ where
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
-            let mut index = i;
-            #[cfg(target_endian = "big")]
-            {
-                // Adjust the index for endianness.
-                index = bit_width as usize - 1 - index;
-            }
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
             self.set_bit(index + bit_offset, val_bit_is_set);
         }
     }


### PR DESCRIPTION
And fixup whitespace.

This is a followup #1342.