### PR TITLE
Fix to accept clang arguments containing white-spaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,7 +846,9 @@ impl Builder {
 
     /// Add an argument to be passed straight through to clang.
     pub fn clang_arg<T: Into<String>>(mut self, arg: T) -> Builder {
-        self.options.clang_args.push(arg.into());
+        for arg in arg.into().split_whitespace() {
+            self.options.clang_args.push(arg.to_string());
+        }
         self
     }
 


### PR DESCRIPTION
This PR prevents misbehavior from occurring when clang-arguments containing white spaces(e.g. "-x c++") are given for `Builder::clang_arg` and `Builder::clang_args`.