### PR TITLE
Change a call to add_item that was passing a NullCursor.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -50,13 +50,6 @@ impl Cursor {
         unsafe { clang_isDeclaration(self.kind()) != 0 }
     }
 
-    /// Get the null cursor, which has no referent.
-    pub fn null() -> Self {
-        Cursor {
-            x: unsafe { clang_getNullCursor() },
-        }
-    }
-
     /// Get this cursor's referent's spelling.
     pub fn spelling(&self) -> String {
         unsafe { cxstring_into_string(clang_getCursorSpelling(self.x)) }

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -686,7 +686,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         debug_assert!(
             declaration.is_some() || !item.kind().is_type() ||
                 item.kind().expect_type().is_builtin_or_type_param() ||
-                item.kind().expect_type().is_opaque(self, &item),
+                item.kind().expect_type().is_opaque(self, &item) ||
+                item.kind().expect_type().is_unresolved_ref(),
             "Adding a type without declaration?"
         );
 

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1409,7 +1409,7 @@ impl ClangItemParser for Item {
                 parent_id.unwrap_or(current_module.into()),
                 ItemKind::Type(Type::new(None, None, kind, is_const)),
             ),
-            Some(clang::Cursor::null()),
+            None,
             None,
         );
         potential_id.as_type_id_unchecked()

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -216,6 +216,14 @@ impl Type {
         }
     }
 
+    /// Is this an unresolved reference?
+    pub fn is_unresolved_ref(&self) -> bool {
+        match self.kind {
+            TypeKind::UnresolvedTypeRef(_, _, _) => true,
+            _ => false,
+        }
+    }
+
     /// Is this a incomplete array type?
     pub fn is_incomplete_array(&self, ctx: &BindgenContext) -> Option<ItemId> {
         match self.kind {


### PR DESCRIPTION
As a first step for issue #119, I modified the only call where we created a NullCursor to pass a None instead.