### PR TITLE
Remove an out-of-date comment in RegexSet.

### DIFF
--- a/src/regex_set.rs
+++ b/src/regex_set.rs
@@ -2,9 +2,6 @@
 
 use regex::RegexSet as RxSet;
 
-// Yeah, I'm aware this is sorta crappy, should be cheaper to compile a regex
-// ORing all the patterns, I guess...
-
 /// A dynamic set of regular expressions.
 #[derive(Debug)]
 pub struct RegexSet {


### PR DESCRIPTION
RegexSet uses `regex::RegexSet` internally since https://github.com/rust-lang-nursery/rust-bindgen/commit/51f5162f250a5ec10bc5ba8b91b60b45762bc999, which implements the method described in the comment.