### PR TITLE
options: mark clang-args last

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -150,6 +150,7 @@ where
                 .help("Time the different bindgen phases and print to stderr"),
             // All positional arguments after the end of options marker, `--`
             Arg::with_name("clang-args")
+                .last(true)
                 .multiple(true),
             Arg::with_name("emit-clang-ast")
                 .long("emit-clang-ast")


### PR DESCRIPTION
before, `bindgen -- -I blah` would try to open `-I` as a header file, leading to a very confusing error message.

The "real" use case behind this is described here: https://github.com/NixOS/nixpkgs/pull/45330

I have checked that these ways of passing args still work/error as expected:
```
bindgen a.h
bindgen a.h --
bindgen a.h -- -Dblah=1
bindgen -- -Dblah=1
bindgen --
bindgen
```