### PR TITLE
Indicate the anonymous lifetime in Formatter.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -23,7 +23,7 @@ pub struct Cursor {
 }
 
 impl fmt::Debug for Cursor {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
             "Cursor({} kind: {}, loc: {}, usr: {:?})",
@@ -746,7 +746,7 @@ impl PartialEq for Type {
 impl Eq for Type {}
 
 impl fmt::Debug for Type {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
             "Type({}, kind: {}, cconv: {}, decl: {:?}, canon: {:?})",
@@ -1153,7 +1153,7 @@ impl SourceLocation {
 }
 
 impl fmt::Display for SourceLocation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (file, line, col, _) = self.location();
         if let Some(name) = file.name() {
             write!(f, "{}:{}:{}", name, line, col)
@@ -1314,7 +1314,7 @@ impl Index {
 }
 
 impl fmt::Debug for Index {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Index {{ }}")
     }
 }
@@ -1342,7 +1342,7 @@ pub struct TranslationUnit {
 }
 
 impl fmt::Debug for TranslationUnit {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "TranslationUnit {{ }}")
     }
 }
@@ -1482,7 +1482,7 @@ impl UnsavedFile {
 }
 
 impl fmt::Debug for UnsavedFile {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
             "UnsavedFile(name: {:?}, contents: {:?})",

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -23,7 +23,7 @@ pub struct Cursor {
 }
 
 impl fmt::Debug for Cursor {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             fmt,
             "Cursor({} kind: {}, loc: {}, usr: {:?})",
@@ -746,7 +746,7 @@ impl PartialEq for Type {
 impl Eq for Type {}
 
 impl fmt::Debug for Type {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             fmt,
             "Type({}, kind: {}, cconv: {}, decl: {:?}, canon: {:?})",
@@ -1153,7 +1153,7 @@ impl SourceLocation {
 }
 
 impl fmt::Display for SourceLocation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (file, line, col, _) = self.location();
         if let Some(name) = file.name() {
             write!(f, "{}:{}:{}", name, line, col)
@@ -1314,7 +1314,7 @@ impl Index {
 }
 
 impl fmt::Debug for Index {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "Index {{ }}")
     }
 }
@@ -1342,7 +1342,7 @@ pub struct TranslationUnit {
 }
 
 impl fmt::Debug for TranslationUnit {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "TranslationUnit {{ }}")
     }
 }
@@ -1482,7 +1482,7 @@ impl UnsavedFile {
 }
 
 impl fmt::Debug for UnsavedFile {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             fmt,
             "UnsavedFile(name: {:?}, contents: {:?})",

--- a/src/codegen/error.rs
+++ b/src/codegen/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", error::Error::description(self))
     }
 }

--- a/src/codegen/error.rs
+++ b/src/codegen/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", error::Error::description(self))
     }
 }

--- a/src/codegen/impl_debug.rs
+++ b/src/codegen/impl_debug.rs
@@ -45,7 +45,7 @@ pub fn gen_debug_impl(
     let prefix = ctx.trait_prefix();
 
     quote! {
-        fn fmt(&self, f: &mut ::#prefix::fmt::Formatter) -> ::#prefix ::fmt::Result {
+        fn fmt(&self, f: &mut ::#prefix::fmt::Formatter<'_>) -> ::#prefix ::fmt::Result {
             write!(f, #( #tokens ),*)
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3678,7 +3678,7 @@ mod utils {
 
         let union_field_debug_impl = quote! {
             impl<T> ::#prefix::fmt::Debug for __BindgenUnionField<T> {
-                fn fmt(&self, fmt: &mut ::#prefix::fmt::Formatter)
+                fn fmt(&self, fmt: &mut ::#prefix::fmt::Formatter<'_>)
                        -> ::#prefix::fmt::Result {
                     fmt.write_str("__BindgenUnionField")
                 }
@@ -3765,7 +3765,7 @@ mod utils {
 
         let incomplete_array_debug_impl = quote! {
             impl<T> ::#prefix::fmt::Debug for __IncompleteArrayField<T> {
-                fn fmt(&self, fmt: &mut ::#prefix::fmt::Formatter)
+                fn fmt(&self, fmt: &mut ::#prefix::fmt::Formatter<'_>)
                        -> ::#prefix::fmt::Result {
                     fmt.write_str("__IncompleteArrayField")
                 }

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/anon_union_1_0.rs
+++ b/tests/expectations/tests/anon_union_1_0.rs
@@ -32,7 +32,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/blacklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blacklist-and-impl-debug.rs
@@ -40,7 +40,7 @@ impl Default for ShouldManuallyImplDebug {
     }
 }
 impl ::std::fmt::Debug for ShouldManuallyImplDebug {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "ShouldManuallyImplDebug {{  }}")
     }
 }

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -30,7 +30,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -30,7 +30,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }
@@ -71,7 +71,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -32,7 +32,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -152,7 +152,7 @@ impl Default for Foo {
     }
 }
 impl ::std::fmt::Debug for Foo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
             f,
             "Foo {{ large: [{}], type_ : {:?},  }}",

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -142,7 +142,7 @@ impl Default for C {
     }
 }
 impl ::core::fmt::Debug for C {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(
             f,
             "C {{ a : {:?}, b : {:?}, large_array: [...] }}",

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -135,7 +135,7 @@ impl Default for C {
     }
 }
 impl ::std::fmt::Debug for C {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
             f,
             "C {{ a : {:?}, b : {:?}, large_array: [{}] }}",

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -50,7 +50,7 @@ impl Default for Nice {
     }
 }
 impl ::std::fmt::Debug for Nice {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
             f,
             "Nice {{ pointer: {:?}, large_array: [{}] }}",

--- a/tests/expectations/tests/derive-debug-generic.rs
+++ b/tests/expectations/tests/derive-debug-generic.rs
@@ -15,7 +15,7 @@ impl<T> Default for Generic<T> {
     }
 }
 impl<T> ::std::fmt::Debug for Generic<T> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Generic {{ t: Array with length 40 }}")
     }
 }

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -57,7 +57,7 @@ impl Default for perf_event_attr__bindgen_ty_1 {
     }
 }
 impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "perf_event_attr__bindgen_ty_1 {{ union }}")
     }
 }
@@ -100,7 +100,7 @@ impl Default for perf_event_attr {
     }
 }
 impl ::std::fmt::Debug for perf_event_attr {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
             f,
             "perf_event_attr {{ type: {:?}, a: {:?}, __bindgen_anon_1: {:?} }}",

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -37,7 +37,7 @@ impl Default for Instance {
     }
 }
 impl ::std::fmt::Debug for Instance {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Instance {{ val: opaque }}")
     }
 }

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -27,7 +27,7 @@ impl Default for Opaque {
     }
 }
 impl ::std::fmt::Debug for Opaque {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Opaque {{ opaque }}")
     }
 }
@@ -64,7 +64,7 @@ impl Default for OpaqueUser {
     }
 }
 impl ::std::fmt::Debug for OpaqueUser {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "OpaqueUser {{ opaque: {:?} }}", self.opaque)
     }
 }

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -30,7 +30,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/issue-493.rs
+++ b/tests/expectations/tests/issue-493.rs
@@ -32,7 +32,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/issue-493_1_0.rs
+++ b/tests/expectations/tests/issue-493_1_0.rs
@@ -32,7 +32,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -30,7 +30,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -130,7 +130,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -131,7 +131,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -135,7 +135,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -33,7 +33,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -135,7 +135,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -36,7 +36,7 @@ pub mod root {
     }
     impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
     impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-        fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             fmt.write_str("__BindgenUnionField")
         }
     }

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -135,7 +135,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_template_1_0.rs
+++ b/tests/expectations/tests/union_template_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -130,7 +130,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -34,7 +34,7 @@ impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -35,7 +35,7 @@ impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 }
 impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
 impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         fmt.write_str("__BindgenUnionField")
     }
 }

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -30,7 +30,7 @@ impl<T> __IncompleteArrayField<T> {
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         fmt.write_str("__IncompleteArrayField")
     }
 }

--- a/tests/quickchecking/src/fuzzers.rs
+++ b/tests/quickchecking/src/fuzzers.rs
@@ -196,7 +196,7 @@ impl Arbitrary for DeclarationC {
 
 /// Enables to string and format for DeclarationC types.
 impl fmt::Display for DeclarationC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DeclarationC::FunctionPtrDecl(ref d) => write!(f, "{}", d),
             DeclarationC::StructDecl(ref d) => write!(f, "{}", d),
@@ -219,7 +219,7 @@ impl Arbitrary for DeclarationListC {
 
 /// Enables to string and format for DeclarationListC types.
 impl fmt::Display for DeclarationListC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut display = String::new();
         for decl in &self.decls {
             display += &format!("{}", decl);
@@ -274,7 +274,7 @@ impl Arbitrary for BaseTypeC {
 
 /// Enables to string and format for BaseTypeC types,
 impl fmt::Display for BaseTypeC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.def)
     }
 }
@@ -292,7 +292,7 @@ impl Arbitrary for TypeQualifierC {
 
 /// Enables to string and format for TypeQualifierC types.
 impl fmt::Display for TypeQualifierC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.def)
     }
 }
@@ -310,7 +310,7 @@ impl Arbitrary for PointerLevelC {
 
 /// Enables to string and format for PointerLevelC types.
 impl fmt::Display for PointerLevelC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.def)
     }
 }
@@ -340,7 +340,7 @@ impl Arbitrary for ArrayDimensionC {
 
 /// Enables to string and format for ArrayDimensionC types.
 impl fmt::Display for ArrayDimensionC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.def)
     }
 }
@@ -369,7 +369,7 @@ impl Arbitrary for BasicTypeDeclarationC {
 
 /// Enables to string and format for BasicTypeDeclarationC types.
 impl fmt::Display for BasicTypeDeclarationC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} ident_{}{};",
@@ -421,7 +421,7 @@ impl Arbitrary for StructDeclarationC {
 
 /// Enables to string and format for StructDeclarationC types.
 impl fmt::Display for StructDeclarationC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "struct {{ {} }} struct_{}{};",
@@ -471,7 +471,7 @@ impl Arbitrary for UnionDeclarationC {
 
 /// Enables to string and format for UnionDeclarationC types.
 impl fmt::Display for UnionDeclarationC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "union {{ {} }} union_{}{};",
@@ -506,7 +506,7 @@ impl Arbitrary for FunctionPointerDeclarationC {
 
 /// Enables to string and format for FunctionPointerDeclarationC types.
 impl fmt::Display for FunctionPointerDeclarationC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} (*func_ptr_{})({});",
@@ -543,7 +543,7 @@ impl Arbitrary for FunctionPrototypeC {
 
 /// Enables to string and format for FunctionPrototypeC types.
 impl fmt::Display for FunctionPrototypeC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} func_{}({});",
@@ -570,7 +570,7 @@ impl Arbitrary for ParameterC {
 
 /// Enables to string and format for ParameterC types.
 impl fmt::Display for ParameterC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {}",
@@ -593,7 +593,7 @@ impl Arbitrary for ParameterListC {
 
 /// Enables to string and format for ParameterListC types.
 impl fmt::Display for ParameterListC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut display = String::new();
         for (i, p) in self.params.iter().enumerate() {
             match i {
@@ -619,7 +619,7 @@ impl Arbitrary for HeaderC {
 
 /// Enables to string and format for HeaderC types.
 impl fmt::Display for HeaderC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut display = String::new();
         for decl in &self.def.decls {
             display += &format!("{}", decl);
@@ -631,7 +631,7 @@ impl fmt::Display for HeaderC {
 /// Use Display trait for Debug so that any failing property tests report
 /// generated C code rather than the data structures that contain it.
 impl fmt::Debug for HeaderC {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }


### PR DESCRIPTION
Not indicating this lifetime is a warning and I haven't figured out how to make clippy ignore it when using "-D warnings".

Like so:

```
warning: hidden lifetime parameters in types are deprecated
   --> /home/jakubkozlowski/Programming/starfish/target/debug/build/spdk-sys-f36c12b8dbef03e3/out/spdk_bindings.rs:127:29
    |
127 |     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
    |                             ^^^^^^^^^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
```