### PR TITLE
Skip bitfield unit tests on big-endian platforms.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,7 +7,7 @@ pub mod struct_layout;
 #[cfg(test)]
 #[allow(warnings)]
 pub(crate) mod bitfield_unit;
-#[cfg(test)]
+#[cfg(all(test, target_endian = "little"))]
 mod bitfield_unit_tests;
 
 use self::helpers::attributes;


### PR DESCRIPTION
Fixes #1412.