### PR TITLE
Docs: Update bindgen version in tutorial.

### DIFF
--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -5,5 +5,5 @@ Declare a build-time dependency on `bindgen` by adding it to the
 
 ```toml
 [build-dependencies]
-bindgen = "0.26.3"
+bindgen = "0.42.2"
 ```


### PR DESCRIPTION
The version listed in the tutorial quite old (0.26.3) and I used it without thinking when following the tutorial. It'd be nice if it were more up to date.